### PR TITLE
Refactor typography system and improve demo components

### DIFF
--- a/catalog/src/main/java/com/cortena/ui/catalog/MainActivity.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/MainActivity.kt
@@ -1,23 +1,46 @@
+/*
+ * CortenaUI Catalog
+ * Copyright (C) 2026  CortenaOS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
 package com.cortena.ui.catalog
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.cortena.ui.catalog.demo.ButtonDemo
 import com.cortena.ui.catalog.demo.ColorDemo
 import com.cortena.ui.catalog.demo.SliderDemo
 import com.cortena.ui.catalog.demo.ToggleDemo
+import com.cortena.ui.catalog.demo.TypographyDemo
+import com.cortena.ui.components.Separator
 import com.cortena.ui.components.Text
+import com.cortena.ui.components.TextRole
+import com.cortena.ui.components.Toggle
 import com.cortena.ui.layout.Body
 import com.cortena.ui.layout.ContentView
 import com.cortena.ui.layout.SafeArea
 import com.cortena.ui.layout.ScrollView
+import com.cortena.ui.theme.LocalColors
 import com.cortena.ui.theme.ThemeMode
 
 class MainActivity : ComponentActivity() {
@@ -34,13 +57,42 @@ class MainActivity : ComponentActivity() {
                             modifier = Modifier.fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(16.dp),
                         ) {
+                            val colors = LocalColors.current
                             Text(
-                                "Long click to switch ThemeMode",
-                                modifier = Modifier.padding(top = 16.dp),
+                                "Theme",
+                                color = Color(colors.primary),
+                                role = TextRole.TitleMedium,
                             )
-                            ButtonDemo(themeMode)
+                            val isSystemDark = isSystemInDarkTheme()
+                            val isDark =
+                                when (themeMode.value) {
+                                    ThemeMode.Light -> false
+                                    ThemeMode.Dark -> true
+                                    ThemeMode.Auto -> isSystemDark
+                                }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text("Dark Mode")
+                                Toggle(
+                                    checked = isDark,
+                                    onCheckedChange = {
+                                        themeMode.value =
+                                            if (isDark) ThemeMode.Light else ThemeMode.Dark
+                                    },
+                                )
+                            }
+                            Separator(modifier = Modifier.padding(vertical = 12.dp))
+                            TypographyDemo()
+                            Separator(modifier = Modifier.padding(vertical = 12.dp))
+                            ButtonDemo()
+                            Separator(modifier = Modifier.padding(vertical = 12.dp))
                             SliderDemo()
+                            Separator(modifier = Modifier.padding(vertical = 12.dp))
                             ToggleDemo()
+                            Separator(modifier = Modifier.padding(vertical = 12.dp))
                             ColorDemo()
                         }
                     }

--- a/catalog/src/main/java/com/cortena/ui/catalog/demo/Button.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/demo/Button.kt
@@ -9,7 +9,11 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -18,84 +22,57 @@ import com.cortena.ui.components.Button
 import com.cortena.ui.components.ButtonStyle
 import com.cortena.ui.components.ButtonVariant
 import com.cortena.ui.components.Text
-import com.cortena.ui.theme.ThemeMode
+import com.cortena.ui.components.TextRole
+import com.cortena.ui.components.Toggle
+import com.cortena.ui.theme.LocalColors
 import com.cortena.ui.theme.value
 
 @Composable
-fun ButtonDemo(themeMode: MutableState<ThemeMode>) {
-    Button(
-        onLongClick = {
-            themeMode.value =
-                when (themeMode.value) {
-                    ThemeMode.Light -> ThemeMode.Dark
-                    ThemeMode.Dark -> ThemeMode.Light
-                    ThemeMode.Auto -> ThemeMode.Light
-                }
-        }
+fun ButtonDemo() {
+    val colors = LocalColors.current
+    Text("Button", color = Color(colors.primary), role = TextRole.TitleMedium)
+    var enable by remember { mutableStateOf(true) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            when (themeMode.value) {
-                ThemeMode.Light -> "Switch to Dark"
-                ThemeMode.Dark -> "Switch to Light"
-                ThemeMode.Auto -> "Switch to Light"
-            }
-        )
+        Text("Enable Button")
+        Toggle(checked = enable, onCheckedChange = { enable = it })
     }
-    Text("Button")
+    Text("Button Default")
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Primary) { Text("Primary") }
-        Button(style = ButtonStyle.Secondary) { Text("Secondary") }
-        Button(style = ButtonStyle.Accent) { Text("Accent") }
+        Button(enabled = enable, style = ButtonStyle.Primary) { Text("Primary") }
+        Button(enabled = enable, style = ButtonStyle.Secondary) { Text("Secondary") }
+        Button(enabled = enable, style = ButtonStyle.Accent) { Text("Accent") }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Ghost) { Text("Ghost") }
-        Button(style = ButtonStyle.Destructive) { Text("Destructive") }
+        Button(enabled = enable, style = ButtonStyle.Ghost) { Text("Ghost") }
+        Button(enabled = enable, style = ButtonStyle.Destructive) { Text("Destructive") }
     }
     Text("Button Soft Variant")
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Primary, variant = ButtonVariant.Soft) { Text("Primary") }
-        Button(style = ButtonStyle.Secondary, variant = ButtonVariant.Soft) { Text("Secondary") }
-        Button(style = ButtonStyle.Accent, variant = ButtonVariant.Soft) { Text("Accent") }
-    }
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Ghost, variant = ButtonVariant.Soft) { Text("Ghost") }
-        Button(style = ButtonStyle.Destructive, variant = ButtonVariant.Soft) {
-            Text("Destructive")
-        }
-    }
-    Text("Button Disabled")
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Primary, enabled = false) { Text("Primary") }
-        Button(style = ButtonStyle.Secondary, enabled = false) { Text("Secondary") }
-        Button(style = ButtonStyle.Accent, enabled = false) { Text("Accent") }
-    }
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Ghost, enabled = false) { Text("Ghost") }
-        Button(style = ButtonStyle.Destructive, enabled = false) { Text("Destructive") }
-    }
-    Text("Button Disabled Soft Variant")
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Primary, variant = ButtonVariant.Soft, enabled = false) {
+        Button(enabled = enable, style = ButtonStyle.Primary, variant = ButtonVariant.Soft) {
             Text("Primary")
         }
-        Button(style = ButtonStyle.Secondary, variant = ButtonVariant.Soft, enabled = false) {
+        Button(enabled = enable, style = ButtonStyle.Secondary, variant = ButtonVariant.Soft) {
             Text("Secondary")
         }
-        Button(style = ButtonStyle.Accent, variant = ButtonVariant.Soft, enabled = false) {
+        Button(enabled = enable, style = ButtonStyle.Accent, variant = ButtonVariant.Soft) {
             Text("Accent")
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(style = ButtonStyle.Ghost, variant = ButtonVariant.Soft, enabled = false) {
+        Button(enabled = enable, style = ButtonStyle.Ghost, variant = ButtonVariant.Soft) {
             Text("Ghost")
         }
-        Button(style = ButtonStyle.Destructive, variant = ButtonVariant.Soft, enabled = false) {
+        Button(enabled = enable, style = ButtonStyle.Destructive, variant = ButtonVariant.Soft) {
             Text("Destructive")
         }
     }
     Text("Other")
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(background = ColorToken.Blue500.value()) {
+        Button(enabled = enable, background = ColorToken.Blue500.value()) {
             Icon(
                 imageVector = Icons.Default.Favorite,
                 contentDescription = "Favorite icon",
@@ -103,15 +80,15 @@ fun ButtonDemo(themeMode: MutableState<ThemeMode>) {
             )
             Text("Favorite", color = ColorToken.Blue50.value())
         }
-        Button(background = ColorToken.Green600.value()) { Text("Green") }
-        Button(iconOnly = true, background = ColorToken.Orange500.value()) {
+        Button(enabled = enable, background = ColorToken.Green600.value()) { Text("Green") }
+        Button(enabled = enable, iconOnly = true, background = ColorToken.Orange500.value()) {
             Icon(
                 imageVector = Icons.Default.Add,
                 contentDescription = "Add icon",
                 tint = Color.White,
             )
         }
-        Button(iconOnly = true, background = ColorToken.Pink500.value()) {
+        Button(enabled = enable, iconOnly = true, background = ColorToken.Pink500.value()) {
             Icon(
                 imageVector = Icons.Default.Edit,
                 contentDescription = "Edit icon",

--- a/catalog/src/main/java/com/cortena/ui/catalog/demo/Color.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/demo/Color.kt
@@ -8,246 +8,315 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.cortena.ui.color.ColorToken
 import com.cortena.ui.components.Text
+import com.cortena.ui.components.TextRole
+import com.cortena.ui.theme.LocalColors
 import com.cortena.ui.theme.value
 
 @Composable
 fun ColorDemo() {
-    Text("Colors")
+    val colors = LocalColors.current
+    Text("Colors", color = Color(colors.primary), role = TextRole.TitleMedium)
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Red50.value(),
-                ColorToken.Red100.value(),
-                ColorToken.Red200.value(),
-                ColorToken.Red300.value(),
-                ColorToken.Red400.value(),
-                ColorToken.Red500.value(),
-                ColorToken.Red600.value(),
-                ColorToken.Red700.value(),
-                ColorToken.Red800.value(),
-                ColorToken.Red900.value(),
-                ColorToken.Red950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Red50.value(),
+            ColorToken.Red100.value(),
+            ColorToken.Red200.value(),
+            ColorToken.Red300.value(),
+            ColorToken.Red400.value(),
+            ColorToken.Red500.value(),
+            ColorToken.Red600.value(),
+            ColorToken.Red700.value(),
+            ColorToken.Red800.value(),
+            ColorToken.Red900.value(),
+            ColorToken.Red950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Orange50.value(),
-                ColorToken.Orange100.value(),
-                ColorToken.Orange200.value(),
-                ColorToken.Orange300.value(),
-                ColorToken.Orange400.value(),
-                ColorToken.Orange500.value(),
-                ColorToken.Orange600.value(),
-                ColorToken.Orange700.value(),
-                ColorToken.Orange800.value(),
-                ColorToken.Orange900.value(),
-                ColorToken.Orange950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Orange50.value(),
+            ColorToken.Orange100.value(),
+            ColorToken.Orange200.value(),
+            ColorToken.Orange300.value(),
+            ColorToken.Orange400.value(),
+            ColorToken.Orange500.value(),
+            ColorToken.Orange600.value(),
+            ColorToken.Orange700.value(),
+            ColorToken.Orange800.value(),
+            ColorToken.Orange900.value(),
+            ColorToken.Orange950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Yellow50.value(),
-                ColorToken.Yellow100.value(),
-                ColorToken.Yellow200.value(),
-                ColorToken.Yellow300.value(),
-                ColorToken.Yellow400.value(),
-                ColorToken.Yellow500.value(),
-                ColorToken.Yellow600.value(),
-                ColorToken.Yellow700.value(),
-                ColorToken.Yellow800.value(),
-                ColorToken.Yellow900.value(),
-                ColorToken.Yellow950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Yellow50.value(),
+            ColorToken.Yellow100.value(),
+            ColorToken.Yellow200.value(),
+            ColorToken.Yellow300.value(),
+            ColorToken.Yellow400.value(),
+            ColorToken.Yellow500.value(),
+            ColorToken.Yellow600.value(),
+            ColorToken.Yellow700.value(),
+            ColorToken.Yellow800.value(),
+            ColorToken.Yellow900.value(),
+            ColorToken.Yellow950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Green50.value(),
-                ColorToken.Green100.value(),
-                ColorToken.Green200.value(),
-                ColorToken.Green300.value(),
-                ColorToken.Green400.value(),
-                ColorToken.Green500.value(),
-                ColorToken.Green600.value(),
-                ColorToken.Green700.value(),
-                ColorToken.Green800.value(),
-                ColorToken.Green900.value(),
-                ColorToken.Green950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Green50.value(),
+            ColorToken.Green100.value(),
+            ColorToken.Green200.value(),
+            ColorToken.Green300.value(),
+            ColorToken.Green400.value(),
+            ColorToken.Green500.value(),
+            ColorToken.Green600.value(),
+            ColorToken.Green700.value(),
+            ColorToken.Green800.value(),
+            ColorToken.Green900.value(),
+            ColorToken.Green950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Mint50.value(),
-                ColorToken.Mint100.value(),
-                ColorToken.Mint200.value(),
-                ColorToken.Mint300.value(),
-                ColorToken.Mint400.value(),
-                ColorToken.Mint500.value(),
-                ColorToken.Mint600.value(),
-                ColorToken.Mint700.value(),
-                ColorToken.Mint800.value(),
-                ColorToken.Mint900.value(),
-                ColorToken.Mint950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Mint50.value(),
+            ColorToken.Mint100.value(),
+            ColorToken.Mint200.value(),
+            ColorToken.Mint300.value(),
+            ColorToken.Mint400.value(),
+            ColorToken.Mint500.value(),
+            ColorToken.Mint600.value(),
+            ColorToken.Mint700.value(),
+            ColorToken.Mint800.value(),
+            ColorToken.Mint900.value(),
+            ColorToken.Mint950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Teal50.value(),
-                ColorToken.Teal100.value(),
-                ColorToken.Teal200.value(),
-                ColorToken.Teal300.value(),
-                ColorToken.Teal400.value(),
-                ColorToken.Teal500.value(),
-                ColorToken.Teal600.value(),
-                ColorToken.Teal700.value(),
-                ColorToken.Teal800.value(),
-                ColorToken.Teal900.value(),
-                ColorToken.Teal950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Teal50.value(),
+            ColorToken.Teal100.value(),
+            ColorToken.Teal200.value(),
+            ColorToken.Teal300.value(),
+            ColorToken.Teal400.value(),
+            ColorToken.Teal500.value(),
+            ColorToken.Teal600.value(),
+            ColorToken.Teal700.value(),
+            ColorToken.Teal800.value(),
+            ColorToken.Teal900.value(),
+            ColorToken.Teal950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Cyan50.value(),
-                ColorToken.Cyan100.value(),
-                ColorToken.Cyan200.value(),
-                ColorToken.Cyan300.value(),
-                ColorToken.Cyan400.value(),
-                ColorToken.Cyan500.value(),
-                ColorToken.Cyan600.value(),
-                ColorToken.Cyan700.value(),
-                ColorToken.Cyan800.value(),
-                ColorToken.Cyan900.value(),
-                ColorToken.Cyan950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Cyan50.value(),
+            ColorToken.Cyan100.value(),
+            ColorToken.Cyan200.value(),
+            ColorToken.Cyan300.value(),
+            ColorToken.Cyan400.value(),
+            ColorToken.Cyan500.value(),
+            ColorToken.Cyan600.value(),
+            ColorToken.Cyan700.value(),
+            ColorToken.Cyan800.value(),
+            ColorToken.Cyan900.value(),
+            ColorToken.Cyan950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Blue50.value(),
-                ColorToken.Blue100.value(),
-                ColorToken.Blue200.value(),
-                ColorToken.Blue300.value(),
-                ColorToken.Blue400.value(),
-                ColorToken.Blue500.value(),
-                ColorToken.Blue600.value(),
-                ColorToken.Blue700.value(),
-                ColorToken.Blue800.value(),
-                ColorToken.Blue900.value(),
-                ColorToken.Blue950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Blue50.value(),
+            ColorToken.Blue100.value(),
+            ColorToken.Blue200.value(),
+            ColorToken.Blue300.value(),
+            ColorToken.Blue400.value(),
+            ColorToken.Blue500.value(),
+            ColorToken.Blue600.value(),
+            ColorToken.Blue700.value(),
+            ColorToken.Blue800.value(),
+            ColorToken.Blue900.value(),
+            ColorToken.Blue950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Indigo50.value(),
-                ColorToken.Indigo100.value(),
-                ColorToken.Indigo200.value(),
-                ColorToken.Indigo300.value(),
-                ColorToken.Indigo400.value(),
-                ColorToken.Indigo500.value(),
-                ColorToken.Indigo600.value(),
-                ColorToken.Indigo700.value(),
-                ColorToken.Indigo800.value(),
-                ColorToken.Indigo900.value(),
-                ColorToken.Indigo950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Indigo50.value(),
+            ColorToken.Indigo100.value(),
+            ColorToken.Indigo200.value(),
+            ColorToken.Indigo300.value(),
+            ColorToken.Indigo400.value(),
+            ColorToken.Indigo500.value(),
+            ColorToken.Indigo600.value(),
+            ColorToken.Indigo700.value(),
+            ColorToken.Indigo800.value(),
+            ColorToken.Indigo900.value(),
+            ColorToken.Indigo950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Purple50.value(),
-                ColorToken.Purple100.value(),
-                ColorToken.Purple200.value(),
-                ColorToken.Purple300.value(),
-                ColorToken.Purple400.value(),
-                ColorToken.Purple500.value(),
-                ColorToken.Purple600.value(),
-                ColorToken.Purple700.value(),
-                ColorToken.Purple800.value(),
-                ColorToken.Purple900.value(),
-                ColorToken.Purple950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Purple50.value(),
+            ColorToken.Purple100.value(),
+            ColorToken.Purple200.value(),
+            ColorToken.Purple300.value(),
+            ColorToken.Purple400.value(),
+            ColorToken.Purple500.value(),
+            ColorToken.Purple600.value(),
+            ColorToken.Purple700.value(),
+            ColorToken.Purple800.value(),
+            ColorToken.Purple900.value(),
+            ColorToken.Purple950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Pink50.value(),
-                ColorToken.Pink100.value(),
-                ColorToken.Pink200.value(),
-                ColorToken.Pink300.value(),
-                ColorToken.Pink400.value(),
-                ColorToken.Pink500.value(),
-                ColorToken.Pink600.value(),
-                ColorToken.Pink700.value(),
-                ColorToken.Pink800.value(),
-                ColorToken.Pink900.value(),
-                ColorToken.Pink950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Pink50.value(),
+            ColorToken.Pink100.value(),
+            ColorToken.Pink200.value(),
+            ColorToken.Pink300.value(),
+            ColorToken.Pink400.value(),
+            ColorToken.Pink500.value(),
+            ColorToken.Pink600.value(),
+            ColorToken.Pink700.value(),
+            ColorToken.Pink800.value(),
+            ColorToken.Pink900.value(),
+            ColorToken.Pink950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Brown50.value(),
-                ColorToken.Brown100.value(),
-                ColorToken.Brown200.value(),
-                ColorToken.Brown300.value(),
-                ColorToken.Brown400.value(),
-                ColorToken.Brown500.value(),
-                ColorToken.Brown600.value(),
-                ColorToken.Brown700.value(),
-                ColorToken.Brown800.value(),
-                ColorToken.Brown900.value(),
-                ColorToken.Brown950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Brown50.value(),
+            ColorToken.Brown100.value(),
+            ColorToken.Brown200.value(),
+            ColorToken.Brown300.value(),
+            ColorToken.Brown400.value(),
+            ColorToken.Brown500.value(),
+            ColorToken.Brown600.value(),
+            ColorToken.Brown700.value(),
+            ColorToken.Brown800.value(),
+            ColorToken.Brown900.value(),
+            ColorToken.Brown950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         for (i in
-            arrayOf(
-                ColorToken.Gray50.value(),
-                ColorToken.Gray100.value(),
-                ColorToken.Gray200.value(),
-                ColorToken.Gray300.value(),
-                ColorToken.Gray400.value(),
-                ColorToken.Gray500.value(),
-                ColorToken.Gray600.value(),
-                ColorToken.Gray700.value(),
-                ColorToken.Gray800.value(),
-                ColorToken.Gray900.value(),
-                ColorToken.Gray950.value(),
-            )) {
-            Box(modifier = Modifier.height(32.dp).weight(1f).background(i))
+        arrayOf(
+            ColorToken.Gray50.value(),
+            ColorToken.Gray100.value(),
+            ColorToken.Gray200.value(),
+            ColorToken.Gray300.value(),
+            ColorToken.Gray400.value(),
+            ColorToken.Gray500.value(),
+            ColorToken.Gray600.value(),
+            ColorToken.Gray700.value(),
+            ColorToken.Gray800.value(),
+            ColorToken.Gray900.value(),
+            ColorToken.Gray950.value(),
+        )) {
+            Box(
+                modifier = Modifier
+                    .height(32.dp)
+                    .weight(1f)
+                    .background(i)
+            )
         }
     }
 }

--- a/catalog/src/main/java/com/cortena/ui/catalog/demo/Slider.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/demo/Slider.kt
@@ -1,49 +1,48 @@
 package com.cortena.ui.catalog.demo
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import com.cortena.ui.components.Button
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.cortena.ui.components.Slider
 import com.cortena.ui.components.Text
+import com.cortena.ui.components.TextRole
+import com.cortena.ui.components.Toggle
+import com.cortena.ui.theme.LocalColors
 
 @Composable
 fun SliderDemo() {
+    val colors = LocalColors.current
+    Text("Slider", color = Color(colors.primary), role = TextRole.TitleMedium)
+    var enable by remember { mutableStateOf(true) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Enable Slider")
+        Toggle(checked = enable, onCheckedChange = { enable = it })
+    }
     var sliderValue by remember { mutableFloatStateOf(0f) }
     Text("Slider")
     Column {
         Text("value int: ${sliderValue.toInt()}")
         Text("value float: $sliderValue")
     }
-    Slider(value = { sliderValue }, onValueChange = { sliderValue = it }, valueRange = -4f..4f)
-    var sliderValue2 by remember { mutableFloatStateOf(0f) }
-    var sliderDisabled by remember { mutableStateOf(false) }
-    Text("Slider Disabled")
-    Button(
-        onClick = {
-            sliderDisabled =
-                when (sliderDisabled) {
-                    true -> false
-                    false -> true
-                }
-        }
-    ) {
-        Text(
-            when (sliderDisabled) {
-                true -> "Disabled"
-                false -> "Enabled"
-            }
-        )
-    }
     Slider(
-        value = { sliderValue2 },
-        onValueChange = { sliderValue2 = it },
+        value = { sliderValue },
+        onValueChange = { sliderValue = it },
         valueRange = -4f..4f,
-        enabled = sliderDisabled,
+        enabled = enable
     )
     var sliderDiscreteValue by remember { mutableFloatStateOf(0f) }
     Text("Slider Discrete")
@@ -53,14 +52,6 @@ fun SliderDemo() {
         onValueChange = { sliderDiscreteValue = it },
         valueRange = -2f..2f,
         steps = 3, // Creates 4 intervals between -2 and 2, meaning a step size of 1f.
-    )
-    var sliderDiscreteDisabledValue by remember { mutableFloatStateOf(0f) }
-    Text("Slider Discrete (Disabled)")
-    Slider(
-        value = { sliderDiscreteDisabledValue },
-        onValueChange = { sliderDiscreteDisabledValue = it },
-        valueRange = -2f..2f,
-        steps = 3,
-        enabled = false,
+        enabled = enable
     )
 }

--- a/catalog/src/main/java/com/cortena/ui/catalog/demo/Toggle.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/demo/Toggle.kt
@@ -10,13 +10,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.cortena.ui.color.ColorToken
+import androidx.compose.ui.graphics.Color
 import com.cortena.ui.components.Text
+import com.cortena.ui.components.TextRole
 import com.cortena.ui.components.Toggle
-import com.cortena.ui.theme.value
+import com.cortena.ui.theme.LocalColors
 
 @Composable
 fun ToggleDemo() {
+    val colors = LocalColors.current
+    Text("Toggle", color = Color(colors.primary), role = TextRole.TitleMedium)
     var defaultChecked by remember { mutableStateOf(true) }
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -26,7 +29,6 @@ fun ToggleDemo() {
         Text("Default Toggle")
         Toggle(checked = defaultChecked, onCheckedChange = { defaultChecked = it })
     }
-    var disabledChecked by remember { mutableStateOf(true) }
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -34,8 +36,8 @@ fun ToggleDemo() {
     ) {
         Text("Disabled Toggle")
         Toggle(
-            checked = disabledChecked,
-            onCheckedChange = { disabledChecked = it },
+            checked = defaultChecked,
+            onCheckedChange = { defaultChecked = it },
             enabled = false,
         )
     }
@@ -49,7 +51,7 @@ fun ToggleDemo() {
         Toggle(
             checked = customChecked,
             onCheckedChange = { customChecked = it },
-            activeColor = ColorToken.Yellow400.value(),
+            activeColor = Color(colors.primary),
         )
     }
 }

--- a/catalog/src/main/java/com/cortena/ui/catalog/demo/Typography.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/demo/Typography.kt
@@ -1,0 +1,162 @@
+package com.cortena.ui.catalog.demo
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cortena.ui.components.Text
+import com.cortena.ui.components.TextRole
+import com.cortena.ui.theme.LocalColors
+
+@Composable
+fun TypographyDemo() {
+    val colors = LocalColors.current
+    Text("Typography", color = Color(colors.primary), role = TextRole.TitleMedium)
+    Text("Display", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Column {
+        Text("Display Large", role = TextRole.DisplayLarge)
+        Text("Display Medium", role = TextRole.DisplayMedium)
+        Text("Display Small", role = TextRole.DisplaySmall)
+        Text(
+            "Display Large Italic",
+            role = TextRole.DisplayLarge,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Display Medium Italic",
+            role = TextRole.DisplayMedium,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Display Small Italic",
+            role = TextRole.DisplaySmall,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+    }
+    Text("Headline", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Column {
+        Text("Headline Large", role = TextRole.HeadlineLarge)
+        Text("Headline Medium", role = TextRole.HeadlineMedium)
+        Text("Headline Small", role = TextRole.HeadlineSmall)
+        Text(
+            "Headline Large Italic",
+            role = TextRole.HeadlineLarge,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Headline Medium Italic",
+            role = TextRole.HeadlineMedium,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Headline Small Italic",
+            role = TextRole.HeadlineSmall,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+    }
+    Text("Title", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Column {
+        Text("Title Large", role = TextRole.TitleLarge)
+        Text("Title Medium", role = TextRole.TitleMedium)
+        Text("Title Small", role = TextRole.TitleSmall)
+        Text(
+            "Title Large Italic",
+            role = TextRole.TitleLarge,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Title Medium Italic",
+            role = TextRole.TitleMedium,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Title Small Italic",
+            role = TextRole.TitleSmall,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+    }
+    Text(
+        "Body",
+        color = Color(colors.secondary),
+        role = TextRole.LabelLarge,
+        style = TextStyle(fontStyle = FontStyle.Italic),
+    )
+    Column {
+        Text("Body Large", role = TextRole.BodyLarge)
+        Text("Body Medium", role = TextRole.BodyMedium)
+        Text("Body Small", role = TextRole.BodySmall)
+        Text(
+            "Body Large Italic",
+            role = TextRole.BodyLarge,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Body Medium Italic",
+            role = TextRole.BodyMedium,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Body Small Italic",
+            role = TextRole.BodySmall,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+    }
+    Text("Label", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Column {
+        Text("Label Large", role = TextRole.LabelLarge)
+        Text("Label Medium", role = TextRole.LabelMedium)
+        Text("Label Small", role = TextRole.LabelSmall)
+        Text(
+            "Label Large Italic",
+            role = TextRole.LabelLarge,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Label Medium Italic",
+            role = TextRole.LabelMedium,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+        Text(
+            "Label Small Italic",
+            role = TextRole.LabelSmall,
+            style = TextStyle(fontStyle = FontStyle.Italic),
+        )
+    }
+    Text("Advanced Features", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Column {
+        Text(
+            "Custom Color (Accent Role Color)",
+            color = Color(colors.accent),
+            role = TextRole.BodyLarge,
+        )
+        Text(
+            "Merged TextStyle (Underlined + Spacing)",
+            style = TextStyle(textDecoration = TextDecoration.Underline, letterSpacing = 2.sp),
+            role = TextRole.BodyLarge,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        val loremIpsum =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        Text(
+            "Ellipsis Overflow: $loremIpsum",
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            role = TextRole.BodyLarge,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        Text(
+            "Ellipsis Overflow 2 Lines: $loremIpsum",
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            role = TextRole.BodyLarge,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}

--- a/catalog/src/main/java/com/cortena/ui/catalog/demo/Typography.kt
+++ b/catalog/src/main/java/com/cortena/ui/catalog/demo/Typography.kt
@@ -19,7 +19,7 @@ import com.cortena.ui.theme.LocalColors
 fun TypographyDemo() {
     val colors = LocalColors.current
     Text("Typography", color = Color(colors.primary), role = TextRole.TitleMedium)
-    Text("Display", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Text("Display", color = Color(colors.secondary), role = TextRole.TitleMedium)
     Column {
         Text("Display Large", role = TextRole.DisplayLarge)
         Text("Display Medium", role = TextRole.DisplayMedium)
@@ -40,7 +40,7 @@ fun TypographyDemo() {
             style = TextStyle(fontStyle = FontStyle.Italic),
         )
     }
-    Text("Headline", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Text("Headline", color = Color(colors.secondary), role = TextRole.TitleMedium)
     Column {
         Text("Headline Large", role = TextRole.HeadlineLarge)
         Text("Headline Medium", role = TextRole.HeadlineMedium)
@@ -61,7 +61,7 @@ fun TypographyDemo() {
             style = TextStyle(fontStyle = FontStyle.Italic),
         )
     }
-    Text("Title", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Text("Title", color = Color(colors.secondary), role = TextRole.TitleMedium)
     Column {
         Text("Title Large", role = TextRole.TitleLarge)
         Text("Title Medium", role = TextRole.TitleMedium)
@@ -82,12 +82,7 @@ fun TypographyDemo() {
             style = TextStyle(fontStyle = FontStyle.Italic),
         )
     }
-    Text(
-        "Body",
-        color = Color(colors.secondary),
-        role = TextRole.LabelLarge,
-        style = TextStyle(fontStyle = FontStyle.Italic),
-    )
+    Text("Body", color = Color(colors.secondary), role = TextRole.TitleMedium)
     Column {
         Text("Body Large", role = TextRole.BodyLarge)
         Text("Body Medium", role = TextRole.BodyMedium)
@@ -108,7 +103,7 @@ fun TypographyDemo() {
             style = TextStyle(fontStyle = FontStyle.Italic),
         )
     }
-    Text("Label", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Text("Label", color = Color(colors.secondary), role = TextRole.TitleMedium)
     Column {
         Text("Label Large", role = TextRole.LabelLarge)
         Text("Label Medium", role = TextRole.LabelMedium)
@@ -129,7 +124,7 @@ fun TypographyDemo() {
             style = TextStyle(fontStyle = FontStyle.Italic),
         )
     }
-    Text("Advanced Features", color = Color(colors.secondary), role = TextRole.LabelLarge)
+    Text("Advanced Features", color = Color(colors.secondary), role = TextRole.TitleMedium)
     Column {
         Text(
             "Custom Color (Accent Role Color)",

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.ui)
-            implementation(libs.compose.components.resources)
         }
         androidMain.dependencies { implementation(libs.androidx.activity.compose) }
     }

--- a/compose/src/commonMain/kotlin/com/cortena/ui/components/Text.kt
+++ b/compose/src/commonMain/kotlin/com/cortena/ui/components/Text.kt
@@ -4,25 +4,92 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.cortena.ui.theme.LocalColors
 import com.cortena.ui.theme.LocalContentColor
 import com.cortena.ui.theme.LocalTypography
+import com.cortena.ui.typography.FontStyle
+
+enum class TextRole {
+    DisplayLarge,
+    DisplayMedium,
+    DisplaySmall,
+    HeadlineLarge,
+    HeadlineMedium,
+    HeadlineSmall,
+    TitleLarge,
+    TitleMedium,
+    TitleSmall,
+    BodyLarge,
+    BodyMedium,
+    BodySmall,
+    LabelLarge,
+    LabelMedium,
+    LabelSmall,
+}
 
 @Composable
 fun Text(
     text: String,
     modifier: Modifier = Modifier,
-    color: Color = LocalContentColor.current ?: Color(LocalColors.current.onBackground),
-    fontSize: TextUnit = LocalTypography.current.bodyMedium.fontSize.sp,
-    fontFamily: FontFamily? = null,
+    color: Color = Color.Unspecified,
+    style: TextStyle? = null,
+    role: TextRole = TextRole.BodyMedium,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
 ) {
+    val colors = LocalColors.current
+    val typography = LocalTypography.current
+
+    val localContentColor = LocalContentColor.current
+    val resolvedColor =
+        when {
+            color.isSpecified -> color
+            localContentColor != null && localContentColor.isSpecified -> localContentColor
+            else -> Color(colors.onBackground)
+        }
+
+    val roleStyle =
+        when (role) {
+            TextRole.DisplayLarge -> typography.displayLarge
+            TextRole.DisplayMedium -> typography.displayMedium
+            TextRole.DisplaySmall -> typography.displaySmall
+            TextRole.HeadlineLarge -> typography.headlineLarge
+            TextRole.HeadlineMedium -> typography.headlineMedium
+            TextRole.HeadlineSmall -> typography.headlineSmall
+            TextRole.TitleLarge -> typography.titleLarge
+            TextRole.TitleMedium -> typography.titleMedium
+            TextRole.TitleSmall -> typography.titleSmall
+            TextRole.BodyLarge -> typography.bodyLarge
+            TextRole.BodyMedium -> typography.bodyMedium
+            TextRole.BodySmall -> typography.bodySmall
+            TextRole.LabelLarge -> typography.labelLarge
+            TextRole.LabelMedium -> typography.labelMedium
+            TextRole.LabelSmall -> typography.labelSmall
+        }
+
+    val resolvedStyle =
+        TextStyle(
+            fontSize = roleStyle.fontSize.sp,
+            lineHeight = roleStyle.lineHeight.sp,
+            letterSpacing = roleStyle.letterSpacing.sp,
+            fontWeight = FontWeight(roleStyle.fontWeight),
+            fontStyle =
+                if (roleStyle.fontStyle == FontStyle.Italic)
+                    androidx.compose.ui.text.font.FontStyle.Italic
+                else androidx.compose.ui.text.font.FontStyle.Normal,
+        )
+            .merge(style)
+
     BasicText(
         text = text,
         modifier = modifier,
-        style = TextStyle(color = color, fontSize = fontSize, fontFamily = fontFamily),
+        style = resolvedStyle.copy(color = resolvedColor),
+        maxLines = maxLines,
+        overflow = overflow,
     )
 }

--- a/docs/components/Text.md
+++ b/docs/components/Text.md
@@ -1,15 +1,14 @@
 # Text
 
-`Text` is the fundamental component in CortenaUI to render strings/sentences on the screen. Unlike standard `Text` functions of Jetpack Compose or Material3, _Cortena Text_ is hardwired into the standard typography theme of the Cortena operating system, eliminating the need for developers to depend on the Material Theme.
+`Text` is the fundamental typography component in CortenaUI used to render strings and sentences on the screen. It is hardwired directly into the standard typography theme of the Cortena operating system, eliminating the need for developers to depend on the Material Theme.
 
 ## Concept
 
-Every text automatically uses base properties from:
+Every text automatically resolves its style based on a semantic role (`TextRole`). This ensures that the appearance of all fonts, text weights, line heights, and colors is uniform and consistent across the operating system without needing to be configured manually on every call.
 
-1. Default color: `LocalColors.current.onBackground`
-2. Default size: `LocalTypography.current.bodyMedium.fontSize.sp`
-
-This ensures that the appearance of all fonts and text colors is uniform and consistent without needing to be reset on every call if you are simply expecting a regular "body sentence" behavior.
+1. **Default Color**: Automatically resolves against `LocalContentColor.current` or `LocalColors.current.onBackground`.
+2. **Default Role**: Defaults to `TextRole.BodyMedium` for regular body sentences.
+3. **Typography Scaling**: Automatically resolves font sizes, weights, and line heights in SP based on the chosen semantic role.
 
 ## API Reference
 
@@ -18,32 +17,65 @@ This ensures that the appearance of all fonts and text colors is uniform and con
 fun Text(
     text: String,
     modifier: Modifier = Modifier,
-    color: Color = Color(LocalColors.current.onBackground),
-    fontSize: TextUnit = LocalTypography.current.bodyMedium.fontSize.sp,
-    fontFamily: FontFamily? = null,
+    color: Color = Color.Unspecified,
+    style: TextStyle? = null,
+    role: TextRole = TextRole.BodyMedium,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
 )
 ```
 
 ### Parameters
 
-| Name         | Data Type     | Description                                                                                      |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------------ |
-| `text`       | `String`      | The sentence / text you want to render.                                                          |
-| `modifier`   | `Modifier`    | Standard Compose modifier.                                                                       |
-| `color`      | `Color`       | Text color. The default is a high contrast to your background color (`onBackground`).            |
-| `fontSize`   | `TextUnit`    | The _font scale_ size. The default points to `bodyMedium` from Cortena Typography.               |
-| `fontFamily` | `FontFamily?` | Changes the _font face_ if needed. If `null`, it uses the built-in OS / Compose runtime default. |
+| Name       | Data Type      | Description                                                                                                                        |
+| ---------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `text`     | `String`       | The sentence / text you want to render.                                                                                            |
+| `modifier` | `Modifier`     | Standard Compose modifier.                                                                                                         |
+| `color`    | `Color`        | Text color. Defaults to `Color.Unspecified`, resolving dynamically against `LocalContentColor` or theme's `onBackground` color.    |
+| `style`    | `TextStyle?`   | Custom `TextStyle` to be merged on top of the resolved role style (e.g., custom letter spacing, text decoration). Default: `null`. |
+| `role`     | `TextRole`     | The semantic typography role. Default: `TextRole.BodyMedium`.                                                                      |
+| `maxLines` | `Int`          | Maximum number of lines for the text to span before being truncated. Default: `Int.MAX_VALUE`.                                     |
+| `overflow` | `TextOverflow` | How visual text overflow should be handled (e.g., `TextOverflow.Ellipsis`, `TextOverflow.Clip`). Default: `TextOverflow.Clip`.     |
 
-### Example
+### TextRole Reference
+
+The `TextRole` enum defines 15 distinct semantic scales across 5 categories:
+
+- **Display**: `DisplayLarge`, `DisplayMedium`, `DisplaySmall` (For massive, prominent titles)
+- **Headline**: `HeadlineLarge`, `HeadlineMedium`, `HeadlineSmall` (For main layout headings)
+- **Title**: `TitleLarge`, `TitleMedium`, `TitleSmall` (For section headers and sub-elements)
+- **Body**: `BodyLarge`, `BodyMedium`, `BodySmall` (For standard readable paragraphs and caption notes)
+- **Label**: `LabelLarge`, `LabelMedium`, `LabelSmall` (For buttons, labels, and metadata indicators)
+
+### Examples
+
+#### Using Default Style and Role
 
 ```kotlin
-// Using default style and size
-Text(text = "Hello World!")
+Text(text = "Hello CortenaOS!")
+```
 
-// Using size and color modifications
+#### Using Semantic Roles and Custom Colors
+
+```kotlin
 Text(
-    text = "Large Title",
-    color = Color(LocalColors.current.primary),
-    fontSize = LocalTypography.current.titleLarge.fontSize.sp
+    text = "Large Dashboard Header",
+    role = TextRole.DisplayMedium,
+    color = Color(LocalColors.current.primary)
+)
+```
+
+#### Advanced Customizations (Style Merging & Ellipsis Truncation)
+
+```kotlin
+Text(
+    text = "This is a very long heading that will automatically be truncated with an ellipsis if it exceeds a single line in length.",
+    role = TextRole.TitleMedium,
+    maxLines = 1,
+    overflow = TextOverflow.Ellipsis,
+    style = TextStyle(
+        textDecoration = TextDecoration.Underline,
+        letterSpacing = 1.5.sp
+    )
 )
 ```

--- a/foundation/src/commonMain/kotlin/com/cortena/ui/typography/Typography.kt
+++ b/foundation/src/commonMain/kotlin/com/cortena/ui/typography/Typography.kt
@@ -6,30 +6,47 @@ package com.cortena.ui.typography
  * Semantic typography roles. Maps [TypeScale] values to named roles that components consume.
  * Framework-agnostic data class.
  */
-data class TextStyle(val fontSize: Float, val lineHeight: Float, val letterSpacing: Float = 0f)
+data class TextStyle(
+    val fontSize: Float,
+    val lineHeight: Float,
+    val letterSpacing: Float = 0f,
+    val fontWeight: Int = 400, // 100–900
+    val fontStyle: FontStyle = FontStyle.Normal,
+)
+
+enum class FontStyle {
+    Normal,
+    Italic,
+}
 
 data class Typography(
     val displayLarge: TextStyle =
-        TextStyle(TypeScale.DisplayLarge, TypeScale.LineHeightDisplayLarge),
+        TextStyle(TypeScale.DisplayLarge, TypeScale.LineHeightDisplayLarge, fontWeight = 700),
     val displayMedium: TextStyle =
-        TextStyle(TypeScale.DisplayMedium, TypeScale.LineHeightDisplayMedium),
+        TextStyle(TypeScale.DisplayMedium, TypeScale.LineHeightDisplayMedium, fontWeight = 700),
     val displaySmall: TextStyle =
-        TextStyle(TypeScale.DisplaySmall, TypeScale.LineHeightDisplaySmall),
+        TextStyle(TypeScale.DisplaySmall, TypeScale.LineHeightDisplaySmall, fontWeight = 700),
     val headlineLarge: TextStyle =
-        TextStyle(TypeScale.HeadlineLarge, TypeScale.LineHeightHeadlineLarge),
+        TextStyle(TypeScale.HeadlineLarge, TypeScale.LineHeightHeadlineLarge, fontWeight = 600),
     val headlineMedium: TextStyle =
-        TextStyle(TypeScale.HeadlineMedium, TypeScale.LineHeightHeadlineMedium),
+        TextStyle(TypeScale.HeadlineMedium, TypeScale.LineHeightHeadlineMedium, fontWeight = 600),
     val headlineSmall: TextStyle =
-        TextStyle(TypeScale.HeadlineSmall, TypeScale.LineHeightHeadlineSmall),
-    val titleLarge: TextStyle = TextStyle(TypeScale.TitleLarge, TypeScale.LineHeightTitleLarge),
-    val titleMedium: TextStyle = TextStyle(TypeScale.TitleMedium, TypeScale.LineHeightTitleMedium),
-    val titleSmall: TextStyle = TextStyle(TypeScale.TitleSmall, TypeScale.LineHeightTitleSmall),
+        TextStyle(TypeScale.HeadlineSmall, TypeScale.LineHeightHeadlineSmall, fontWeight = 600),
+    val titleLarge: TextStyle =
+        TextStyle(TypeScale.TitleLarge, TypeScale.LineHeightTitleLarge, fontWeight = 600),
+    val titleMedium: TextStyle =
+        TextStyle(TypeScale.TitleMedium, TypeScale.LineHeightTitleMedium, fontWeight = 500),
+    val titleSmall: TextStyle =
+        TextStyle(TypeScale.TitleSmall, TypeScale.LineHeightTitleSmall, fontWeight = 500),
     val bodyLarge: TextStyle = TextStyle(TypeScale.BodyLarge, TypeScale.LineHeightBodyLarge),
     val bodyMedium: TextStyle = TextStyle(TypeScale.BodyMedium, TypeScale.LineHeightBodyMedium),
     val bodySmall: TextStyle = TextStyle(TypeScale.BodySmall, TypeScale.LineHeightBodySmall),
-    val labelLarge: TextStyle = TextStyle(TypeScale.LabelLarge, TypeScale.LineHeightLabelLarge),
-    val labelMedium: TextStyle = TextStyle(TypeScale.LabelMedium, TypeScale.LineHeightLabelMedium),
-    val labelSmall: TextStyle = TextStyle(TypeScale.LabelSmall, TypeScale.LineHeightLabelSmall),
+    val labelLarge: TextStyle =
+        TextStyle(TypeScale.LabelLarge, TypeScale.LineHeightLabelLarge, fontWeight = 500),
+    val labelMedium: TextStyle =
+        TextStyle(TypeScale.LabelMedium, TypeScale.LineHeightLabelMedium, fontWeight = 500),
+    val labelSmall: TextStyle =
+        TextStyle(TypeScale.LabelSmall, TypeScale.LineHeightLabelSmall, fontWeight = 500),
 )
 
 /** Default typography — override per-role to customize. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ material3 = "1.4.0"
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "icons" }
-compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
*   **Impact:** **High** - Introduces a breaking API change to the foundational `Text` component and significantly overhauls the typography system.
*   **Key Changes:**
    *   **Semantic Typography:** Replaced manual `fontSize` and `fontFamily` configurations in `Text` with a semantic `TextRole` enum (e.g., `DisplayLarge`, `BodyMedium`).
    *   **TextStyle Enhancements:** Added `fontWeight` and `fontStyle` properties directly to the base `TextStyle` data class.
    *   **Catalog Overhaul:** Centralized the Dark Mode toggle in `MainActivity`, and added global `enable`/`disable` switches to individual UI component demos (Button, Slider, Toggle).
    *   **New Demo:** Introduced `TypographyDemo` to visualize all available `TextRole` variants.
    *   **Cleanup:** Removed the unused `compose.components.resources` dependency.

## 2. Visual Overview (Code & Logic Map)

```mermaid
graph TD
    subgraph "UI Catalog (MainActivity.kt & Demos)"
        M["MainActivity()"] -->|"toggles"| TM["isSystemInDarkTheme()"]
        M -->|"renders"| TD["TypographyDemo()"]
        M -->|"renders"| BD["ButtonDemo()"]
    end

    subgraph "UI Components (Text.kt)"
        T["Text()"]
        TR["TextRole Enum"]
        BT["BasicText()"]
    end
    
    subgraph "Foundation (Typography.kt)"
        TS["TextStyle(fontWeight, fontStyle)"]
        TY["Typography"]
    end

    TD -->|"uses"| T
    BD -->|"uses"| T
    T -->|"resolves semantic style"| TR
    TR -->|"maps to scale"| TY
    TY -->|"provides"| TS
    T -->|"merges overrides & renders"| BT

    style T fill:#c8e6c9,color:#1a5e20
    style TY fill:#bbdefb,color:#0d47a1
    style TS fill:#bbdefb,color:#0d47a1
    style BT fill:#fff3e0,color:#e65100
```

## 3. Detailed Change Analysis

### Core Typography Framework
*   **What Changed:** The `Text` component no longer accepts arbitrary font sizes and families by default. Instead, it relies on `TextRole`, which ensures strict adherence to the CortenaOS design system. Font weights and styles (italic vs. normal) are now baked into the foundation `TextStyle` definitions.
*   **API Changes (`Text` Composable):**

| Param | Old Type / Default | New Type / Default | Description |
| :--- | :--- | :--- | :--- |
| `color` | `Color` (Resolved `onBackground`) | `Color` (`Unspecified`) | Now intelligently resolves via `LocalContentColor` or defaults to `onBackground`. |
| `fontSize` | `TextUnit` | ❌ *Removed* | Use `role` or `style` overrides instead. |
| `fontFamily` | `FontFamily?` | ❌ *Removed* | System standardizes font family natively. |
| `role` | 🆕 *New* | `TextRole` (`BodyMedium`) | Semantic mapping to predefined design system scales. |
| `style` | 🆕 *New* | `TextStyle?` (`null`) | Standard object for applying text decorations or overrides. |
| `maxLines` | 🆕 *New* | `Int` (`Int.MAX_VALUE`) | Restricts the number of rendered text lines. |
| `overflow` | 🆕 *New* | `TextOverflow` (`Clip`) | Determines behavior when text exceeds constraints. |

### UI Catalog & Demos
*   **What Changed:** Re-architected how state is managed in the interactive demo app. The `ThemeMode` toggle was pulled up from `ButtonDemo` into the root `MainActivity`, providing a global theme switcher. Individual demo components (`ButtonDemo`, `SliderDemo`, `ToggleDemo`) now include their own internal `enable` toggle switches to preview disabled states efficiently, rather than duplicating components statically.

### Build & Dependencies
*   **What Changed:** Cleaned up project configuration by removing unused compose dependencies.

| Package | Action | Reason |
| :--- | :--- | :--- |
| `org.jetbrains.compose.components:components-resources` | ❌ Removed | No longer required by the Compose module. |

## 4. Impact & Risk Assessment
*   **Breaking Changes:** 
    *   The `Text` composable signature has changed significantly. Any existing UI code passing `fontSize` or `fontFamily` directly to `Text()` will fail to compile. Developers must migrate to using the appropriate `TextRole` or passing a merged `TextStyle` object via the `style` parameter.
*   **Testing Suggestions:** 
    *   **Text Truncation:** Verify that `maxLines` and `overflow = TextOverflow.Ellipsis` render correctly on extremely long localized strings.
    *   **Weight Rendering:** Ensure that the new native `fontWeight` values (e.g., 700 for Display, 500 for Label) render visibly distinct font weights on both Android and Desktop targets.
    *   **Catalog Integrity:** Confirm that toggling "Dark Mode" globally in the catalog successfully propagates color changes to all newly styled `Text` headers (which now rely on `color = Color(colors.primary)`).