### PR TITLE
docs: fix broken link to components documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For documentation, see:
 
 - [Architecture](docs/ARCHITECTURE.md)
 - [Getting Started](docs/GETTING-STARTED.md)
-- [Components Documentation](docs/component)
+- [Components Documentation](docs/components)
 
 ## License
 


### PR DESCRIPTION
Update the relative path from 'docs/component' to 'docs/components' to correct a broken hyperlink.