### PR TITLE
Enhance slider UI with dynamic shadows and improved tick visibility

### DIFF
--- a/compose/src/commonMain/kotlin/com/cortena/ui/components/Slider.kt
+++ b/compose/src/commonMain/kotlin/com/cortena/ui/components/Slider.kt
@@ -148,6 +148,7 @@ fun Slider(
 
         Box(
             Modifier.clip(shape)
+                .graphicsLayer { alpha = if (enabled) 1f else 0.38f }
                 .background(resolvedTrackColor)
                 .drawBehind {
                     val progress = dampedAnimation.progress.fastCoerceIn(0f, 1f)
@@ -160,14 +161,7 @@ fun Slider(
                             )
                             .fastCoerceIn(0f, size.width)
                     drawRect(
-                        resolvedProgressColor.copy(
-                            alpha =
-                                if (!enabled) {
-                                    0.38f
-                                } else {
-                                    1f
-                                }
-                        ),
+                        resolvedProgressColor,
                         topLeft =
                             if (isLtr) {
                                 Offset.Zero
@@ -184,7 +178,6 @@ fun Slider(
                                     }
                             ),
                     )
-
                     if (steps > 0) {
                         val intervalCount = steps + 1
                         val tickRadius = 4.dp.toPx()

--- a/compose/src/commonMain/kotlin/com/cortena/ui/components/Slider.kt
+++ b/compose/src/commonMain/kotlin/com/cortena/ui/components/Slider.kt
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (C) 2026-present The CortenaOS Project
+ */
 package com.cortena.ui.components
 
 import androidx.compose.foundation.background
@@ -193,9 +197,27 @@ fun Slider(
                             val isTickActive = tickProgress <= progress
                             val tickColor =
                                 if (isTickActive) {
-                                    resolvedTrackColor.copy(alpha = 0.38f)
+                                    // Covered by progress: lighten the progressColor
+                                    Color(
+                                        red =
+                                            (resolvedProgressColor.red +
+                                                (1f - resolvedProgressColor.red) * 0.50f),
+                                        green =
+                                            (resolvedProgressColor.green +
+                                                (1f - resolvedProgressColor.green) * 0.50f),
+                                        blue =
+                                            (resolvedProgressColor.blue +
+                                                (1f - resolvedProgressColor.blue) * 0.50f),
+                                        alpha = resolvedProgressColor.alpha,
+                                    )
                                 } else {
-                                    resolvedProgressColor.copy(alpha = 0.38f)
+                                    // Not covered: darken the trackColor
+                                    Color(
+                                        red = resolvedTrackColor.red * 0.50f,
+                                        green = resolvedTrackColor.green * 0.50f,
+                                        blue = resolvedTrackColor.blue * 0.50f,
+                                        alpha = resolvedTrackColor.alpha,
+                                    )
                                 }
                             drawCircle(
                                 color = tickColor,

--- a/compose/src/commonMain/kotlin/com/cortena/ui/components/Toggle.kt
+++ b/compose/src/commonMain/kotlin/com/cortena/ui/components/Toggle.kt
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (C) 2026-present The CortenaOS Project
+ */
 package com.cortena.ui.components
 
 import androidx.compose.foundation.background
@@ -10,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -21,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
@@ -54,6 +60,8 @@ fun Toggle(
     thumbColor: Color = Color.Unspecified,
 ) {
     val colors = LocalColors.current
+    val shape = CapsuleShape()
+
     val trackWidth = 64.dp
     val trackHeight = 28.dp
     val thumbPadding = 2.dp
@@ -64,14 +72,15 @@ fun Toggle(
     val resolvedInactiveColor =
         if (inactiveColor.isSpecified) inactiveColor else Color(colors.surfaceVariant)
     val resolvedThumbColor = if (thumbColor.isSpecified) thumbColor else Color.White
+    val thumbShadow = thumbShadow(resolvedThumbColor, enabled)
 
     val layoutDirection = LocalLayoutDirection.current
     val isLtr = layoutDirection == LayoutDirection.Ltr
     val animationScope = rememberCoroutineScope()
     var didDrag by remember { mutableStateOf(false) }
 
-    val currentChecked by androidx.compose.runtime.rememberUpdatedState(checked)
-    val currentOnCheckedChange by androidx.compose.runtime.rememberUpdatedState(onCheckedChange)
+    val currentChecked by rememberUpdatedState(checked)
+    val currentOnCheckedChange by rememberUpdatedState(onCheckedChange)
 
     val dampedAnimation =
         remember(animationScope) {
@@ -149,7 +158,7 @@ fun Toggle(
     ) {
         Box(
             modifier =
-                Modifier.matchParentSize().clip(CapsuleShape()).drawBehind {
+                Modifier.matchParentSize().clip(shape).drawBehind {
                     val progress = dampedAnimation.progress.fastCoerceIn(0f, 1f)
                     drawRect(lerp(resolvedInactiveColor, resolvedActiveColor, progress))
                 }
@@ -171,17 +180,26 @@ fun Toggle(
                             scaleYMultiplier = dampedAnimation.scaleY,
                         )
                     }
-                    .componentShadow(
-                        Shadow(
-                            radius = 4.dp,
-                            offset = DpOffset(0.dp, 2.dp),
-                            color = ColorToken.Gray900.value().copy(alpha = 0.15f),
-                        ),
-                        CapsuleShape(),
-                    )
-                    .clip(CapsuleShape())
+                    .componentShadow(thumbShadow, shape)
+                    .clip(shape)
                     .background(resolvedThumbColor)
                     .size(thumbWidth, thumbHeight)
         )
     }
+}
+
+@Composable
+private fun thumbShadow(thumbColor: Color, enabled: Boolean): Shadow {
+    val isLight = thumbColor.luminance() > 0.5f
+    val alphaLight =
+        if (enabled) {
+            0.28f
+        } else {
+            0.15f
+        }
+    return Shadow(
+        radius = if (isLight) 12.dp else 8.dp,
+        offset = DpOffset(0.dp, if (isLight) 3.dp else 2.dp),
+        color = ColorToken.Gray900.value().copy(alpha = if (isLight) alphaLight else 0.18f),
+    )
 }


### PR DESCRIPTION
# 🎨 Slider Component UI Refactoring

## 1. High-Level Summary (TL;DR)
*   **Impact:** Low
*   **Key Changes:**
    *   Improved the visual contrast of step tick marks inside the slider.
    *   Fixed how the disabled state opacity is applied, ensuring it uniformly affects the entire slider layer instead of just the progress bar.

## 2. Visual Overview (Code & Logic Map)

```mermaid
graph TD
    subgraph "Slider.kt (UI Component)"
        A["Slider()"]
        B["Modifier.graphicsLayer()"]
        C["drawRect()"]
        D["drawCircle()"]
    end
    
    subgraph "Visual Rendering Goals"
        E["Uniform Disabled State"]
        F["Active Tick Contrast"]
        G["Inactive Tick Contrast"]
    end
    
    A -->|"Applies opacity to"| B
    B -->|"Handles alpha=0.38f"| E
    A -->|"Draws progress bar"| C
    A -->|"Draws step marks"| D
    D -->|"Lightens progress color"| F
    D -->|"Darkens track color"| G

    %% Color Contrast Requirements
    style A fill:#c8e6c9,color:#1a5e20
    style B fill:#bbdefb,color:#0d47a1
    style C fill:#bbdefb,color:#0d47a1
    style D fill:#bbdefb,color:#0d47a1
    style E fill:#fff3e0,color:#e65100
    style F fill:#f3e5f5,color:#7b1fa2
    style G fill:#f3e5f5,color:#7b1fa2
```

## 3. Detailed Change Analysis

### Component: `Slider` UI Component
**What Changed:**
*   **Disabled State Handling:** The logic for rendering the slider when `enabled = false` was simplified. Instead of conditionally changing the alpha of the progress bar in `drawRect()`, the component now applies a `.graphicsLayer { alpha = if (enabled) 1f else 0.38f }` to the parent `Box`. This ensures all children elements (track, progress, ticks) uniformly fade to 38% opacity. (Source: `Slider.kt`)
*   **Tick Mark Colors:** Replaced simple alpha-blending with a dedicated color lightening/darkening algorithm to vastly improve the contrast of tick marks based on whether they are covered by the progress bar or not.
*   **Licensing:** Added standard `SPDX-License-Identifier: GPL-3.0-or-later` and CortenaOS copyright headers.

**Tick Mark Color Configuration Changes:**

| Tick State | Old Logic | New Logic | Reason |
| :--- | :--- | :--- | :--- |
| **Active** (Covered by progress) | `resolvedTrackColor` at 38% alpha | `resolvedProgressColor` mixed with 50% White | Increases contrast against the solid progress bar color. |
| **Inactive** (Not covered) | `resolvedProgressColor` at 38% alpha | `resolvedTrackColor` darkened by 50% (RGB * 0.5) | Increases contrast against the empty track background. |

## 4. Impact & Risk Assessment
*   **Breaking Changes:** None. This is a non-breaking visual enhancement for UI consumers.
*   **Testing Suggestions:**
    *   **Disabled State:** Render a `Slider(enabled = false)` and ensure the track, progress, and tick marks all look uniformly faded.
    *   **Stepped Mode (Light/Dark Themes):** Render a `Slider(steps = 5)` in both Light Mode and Dark Mode. Verify that the tick marks are clearly visible and do not blend into the track or progress bar backgrounds.