### PR TITLE
Update copyright in README and enhance architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ CortenaUI is built around several core principles:
 - Consistent motion and physics
 - Adaptive layouts for future Android form factors
 - Lightweight architecture
-- Minimal third-party dependencies
-- Compose-native APIs without heavy Material dependency
 - System-level scalability for the CortenaOS ecosystem
 
 The framework takes inspiration from the clarity and restraint of Apple platforms combined with fluid and interactive motion systems commonly seen in modern motion-driven interfaces.
@@ -48,7 +46,7 @@ Current documentation:
 ## License
 
 ```
-Copyright (C) 2026  CortenaOS
+Copyright (C) 2026-present  The CortenaOS Project
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,6 +8,10 @@
 :compose  ── depends on ────┘
 ```
 
+`:catalog` depends on `:compose` (and transitively on `:foundation`).
+`:compose` depends on `:foundation`.
+`:foundation` has zero external dependencies.
+
 ## Modules
 
 ### `:foundation`
@@ -15,7 +19,7 @@
 **Zero external dependencies. Pure Kotlin.**
 
 The single source of truth for all design tokens. Framework-agnostic by design:
-values are primitive types (Long for colors, Float for sizes) so this module
+values are primitive types (`Long` for colors, `Float` for sizes) so this module
 can be consumed by Compose, the Android View system, and AOSP build system
 (`Android.bp`) without modification.
 
@@ -37,17 +41,164 @@ foundation/src/commonMain/kotlin/com/cortena/ui/
 
 Compose wrappers and theme layer. Depends on `:foundation`.
 Converts foundation tokens (`Long`/`Float`) to Compose types (`Color`, `TextUnit`, `Dp`).
-Provides `Theme { }` entry point via CompositionLocalProvider.
+Provides `Theme { }` entry point via `CompositionLocalProvider`.
+
+The module is split into `commonMain` (multiplatform-ready) and `androidMain` (Android-specific platform code).
+
+#### `commonMain` — Shared Compose Layer
+
+```
+compose/src/commonMain/kotlin/com/cortena/ui/
+├── annotation/
+│   └── ExperimentalComponentsApi.kt   # opt-in annotation for unstable APIs
+├── components/
+│   ├── Button.kt            # interactive button with 5 styles, 2 variants
+│   ├── Separator.kt         # horizontal / vertical divider line
+│   ├── Slider.kt            # continuous + discrete value slider
+│   ├── Text.kt              # semantic text with 15 TextRole variants
+│   └── Toggle.kt            # spring-animated switch with drag + tap
+├── graphics/
+│   └── shadow/
+│       ├── Shadow.kt                  # shadow data class (radius, offset, color)
+│       ├── ShadowModifier.kt          # Modifier.componentShadow
+│       ├── InnerShadow.kt            # inner shadow rendering
+│       └── InnerShadowModifier.kt     # Modifier.innerShadow
+├── interaction/
+│   ├── DampedAnimation.kt            # spring-physics animation driver
+│   ├── InteractiveAnimation.kt       # graphicsLayer press/drag transforms
+│   ├── InteractiveHighlight.kt       # highlight composable (commonMain)
+│   ├── InteractiveHighlightColor.kt  # highlight color utilities
+│   └── PressGesture.kt              # inspectDragGestures helper
+├── layout/
+│   ├── AppBar.kt            # top app bar slot
+│   ├── Body.kt              # edge-to-edge root wrapper
+│   ├── SafeArea.kt          # system insets padding
+│   └── ScrollView.kt        # scrollable content container
+├── shape/
+│   ├── CapsuleShape.kt     # stadium / pill shape
+│   ├── ComponentShape.kt   # base shape interface
+│   ├── CornerRadii.kt      # per-corner radius spec
+│   ├── CornerStyle.kt      # round vs cut corner mode
+│   ├── RectangleShape.kt   # sharp rectangle
+│   ├── RoundedShape.kt     # uniform rounded rectangle
+│   ├── ShapeCopy.kt        # immutable copy helpers
+│   ├── ShapeLerp.kt        # shape interpolation
+│   └── UnevenShape.kt      # per-corner radius shape
+└── theme/
+    ├── ColorExtensions.kt         # ColorToken.value() helpers
+    ├── LocalProviders.kt          # CompositionLocal definitions
+    ├── StatusBarIconMode.kt       # Light / Dark / Auto enum
+    ├── Theme.kt                   # Theme() composable entry point
+    └── ThemeMode.kt               # Light / Dark / Auto enum
+```
+
+#### `androidMain` — Android Platform Code
+
+```
+compose/src/androidMain/kotlin/com/cortena/ui/
+├── graphics/
+│   └── shadow/              # platform shadow rendering (RenderNode)
+├── interaction/
+│   ├── InteractiveHighlight.kt       # Android-specific highlight with shader
+│   └── InteractiveHighlightShader.kt # AGSL shader for glow effects
+└── layout/
+    └── ContentView.kt       # ComponentActivity.ContentView() entry point
+```
 
 ### `:catalog`
 
 Showcase app. Depends on `:compose` (and transitively `:foundation`).
-Used to develop and visually verify components.
+Used to develop and visually verify all components in a live environment.
+
+```
+catalog/src/main/java/com/cortena/ui/catalog/
+├── MainActivity.kt          # main activity with theme toggle
+└── demo/
+    ├── Button.kt            # ButtonDemo()
+    ├── Color.kt             # ColorDemo() — responsive palette grid
+    ├── ScrollView.kt        # ScrollViewDemo()
+    ├── Slider.kt            # SliderDemo()
+    ├── Toggle.kt            # ToggleDemo()
+    └── Typography.kt        # TypographyDemo() — all 15 TextRoles + advanced features
+```
+
+## Theme System
+
+### CompositionLocal Providers
+
+The theme layer exposes five `CompositionLocal` keys, each provided by the `Theme()` composable:
+
+| Key                 | Type         | Default             | Purpose                                       |
+| ------------------- | ------------ | ------------------- | --------------------------------------------- |
+| `LocalIsDark`       | `Boolean`    | `false`             | Whether the current theme is dark mode        |
+| `LocalColors`       | `Palette`    | `LightPalette`      | Semantic color roles for the active theme     |
+| `LocalContentColor` | `Color?`     | `null`              | Inherited foreground color (scoped by parent) |
+| `LocalTypography`   | `Typography` | `DefaultTypography` | Semantic text style scales                    |
+| `LocalSpacing`      | `Spacing`    | `Spacing`           | 4dp-grid spacing tokens                       |
+
+### ThemeMode Resolution
+
+`ThemeMode.Auto` delegates to `isSystemInDarkTheme()` inside the `Theme()` composable,
+ensuring consistent behavior without manual system-theme checks in outer layouts.
+
+### ContentView Entry Point (Android)
+
+`ComponentActivity.ContentView()` is the recommended Android entry point. It:
+
+1. Calls `enableEdgeToEdge()` for transparent system bars.
+2. Wraps content inside `Theme()` with the provided `themeMode`, `palette`, and `typography`.
+3. Manages status bar icon contrast (`StatusBarIconMode`) reactively via `SideEffect`.
+4. Renders an optional status bar color overlay and `appBar` slot above the main content.
+
+## Component Design Patterns
+
+### Interaction Model
+
+All interactive components (Button, Slider, Toggle) share a common physics-based interaction system:
+
+1. **`DampedAnimation`** — Central animation driver with spring-physics for position, press feedback (scale), and velocity tracking. Uses `Job`-tracked coroutines to prevent stale animation conflicts on rapid successive interactions.
+2. **`inspectDragGestures`** — Low-level gesture detector that emits `onDragStart`, `onDrag`, `onDragEnd`, and `onDragCancel` callbacks without consuming pointer events (allowing parent scroll to still function).
+3. **`applyInteractiveAnimation`** — `graphicsLayer` extension that applies press-scale, translation, and feedback transforms in a single pass.
+4. **`InteractiveHighlight`** — Platform-specific glow/highlight effect (AGSL shader on Android).
+
+### Color Resolution
+
+Components follow a consistent pattern for resolving colors:
+
+```kotlin
+val resolvedColor = if (customColor.isSpecified) customColor else Color(colors.semanticRole)
+```
+
+This allows per-instance color overrides while defaulting to theme-aware semantic roles.
+
+### Shadow System
+
+The `componentShadow` modifier renders drop shadows that remain visible during scale animations (unlike standard `Modifier.shadow` which clips at the original bounds). This is critical for interactive components like Toggle and Slider indicators.
+
+## Documentation
+
+Component documentation is maintained in `docs/components/` following a standardized format:
+
+| Document         | Component                    |
+| ---------------- | ---------------------------- |
+| `AppBar.md`      | Top app bar                  |
+| `Body.md`        | Edge-to-edge root wrapper    |
+| `Button.md`      | Interactive button           |
+| `ContentView.md` | Android activity entry point |
+| `SafeArea.md`    | System insets padding        |
+| `ScrollView.md`  | Scrollable container         |
+| `Separator.md`   | Visual divider line          |
+| `Slider.md`      | Value adjustment slider      |
+| `Text.md`        | Semantic text component      |
+| `Theme.md`       | Theme composable             |
+| `Toggle.md`      | Switch / toggle              |
+
+Each document follows the structure: **Concept → API Reference → Parameters Table → Examples**.
 
 ## Design Decisions
 
 **Why are colors stored as Long?**
-`androidx.compose.ui.graphics.Color` is a Compose type. Storing raw Long in
+`androidx.compose.ui.graphics.Color` is a Compose type. Storing raw `Long` in
 `:foundation` means the token layer has zero dependency on Compose — it can
 be referenced from `Android.bp` builds for ROM integration without pulling
 in the entire Compose runtime.
@@ -56,3 +207,15 @@ in the entire Compose runtime.
 When ROM integration comes, `:foundation` goes into the system image. Compose
 components live in apps. Keeping them in separate modules makes that boundary
 explicit and enforceable by the build system.
+
+**Why `commonMain` / `androidMain` split in `:compose`?**
+The component APIs, shapes, and theme logic are multiplatform-ready in `commonMain`.
+Platform-specific code (edge-to-edge window management, AGSL shaders, `RenderNode` shadows)
+lives in `androidMain`. This separation enables future targets (Desktop, iOS) with
+minimal refactoring.
+
+**Why `DampedAnimation` instead of `Animatable` directly?**
+`DampedAnimation` encapsulates the full interactive lifecycle (press → drag → release)
+with coordinated spring animations for position, scale, and velocity. It manages
+coroutine job tracking internally so components don't need to handle animation
+cancellation logic, preventing thumb-stuck bugs during rapid interactions.


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
*   **Impact:** Low 
*   **Key Changes:**
    *   Expands the `ARCHITECTURE.md` document to explicitly detail the Kotlin Multiplatform (KMP) structure (`commonMain` vs `androidMain`) of the `:compose` module.
    *   Clarifies inter-module dependencies (`:catalog` -> `:compose` -> `:foundation`).
    *   Updates the `README.md` copyright attribution to "The CortenaOS Project".
    *   Removes redundant architectural bullet points from the main `README.md`.

## 2. Visual Overview (Code & Logic Map)
The following diagram illustrates the updated architectural dependencies and the structural split of the `:compose` module as detailed in the documentation changes.

```mermaid
graph TD
    %% High Contrast Theme Colors
    classDef app fill:#c8e6c9,color:#1a5e20,stroke:#1a5e20
    classDef layer fill:#bbdefb,color:#0d47a1,stroke:#0d47a1
    classDef base fill:#fff3e0,color:#e65100,stroke:#e65100
    classDef kmp fill:#f3e5f5,color:#7b1fa2,stroke:#7b1fa2

    Catalog[":catalog (Showcase App)"]:::app --> Compose[":compose (Theme & Wrappers)"]:::layer
    Compose --> Foundation[":foundation (Design Tokens)"]:::base

    subgraph ":compose Module KMP Split"
        CommonMain["commonMain/ (Shared)"]:::kmp
        AndroidMain["androidMain/ (Android)"]:::kmp
    end

    Compose --> CommonMain
    Compose --> AndroidMain
```

## 3. Detailed Change Analysis

### Project Readme (`README.md`)
*   **What Changed:** 
    *   Simplified the introduction by removing bullet points concerning minimal third-party dependencies and Compose-native APIs.
    *   Updated the copyright statement for better organizational accuracy.

| Original Copyright | New Copyright | Reason |
| :--- | :--- | :--- |
| `Copyright (C) 2026 CortenaOS` | `Copyright (C) 2026-present The CortenaOS Project` | Formalizes the copyright under the project name and marks it as ongoing. |

### Architecture Documentation (`docs/ARCHITECTURE.md`)
*   **What Changed:** 
    *   Added explicit rules stating `:foundation` has zero external dependencies, while `:catalog` depends transitively on `:foundation`.
    *   Fixed minor markdown syntax issues (wrapping `Long` and `Float` in backticks).
    *   Provided a comprehensive directory tree for the `:compose` module, splitting it into multiplatform-ready (`commonMain`) and Android-specific (`androidMain`) layers.

**Compose Module Package Structure:**

| Package | Source Set | Description |
| :--- | :--- | :--- |
| `components` | `commonMain` | Core interactive UI elements (`Button`, `Text`, `Slider`, `Toggle`, `Separator`). |
| `graphics/shadow` | Both | `commonMain` defines shadow data classes; `androidMain` handles `RenderNode` platform rendering. |
| `interaction` | Both | Spring physics and gestures in `commonMain`; AGSL glow shaders in `androidMain`. |
| `layout` | Both | Layout slots (`AppBar`, `SafeArea`) in `commonMain`; `ContentView` entry point in `androidMain`. |
| `shape` | `commonMain` | Immutable geometry specifications (`CapsuleShape`, `RoundedShape`, `UnevenShape`). |
| `theme` | `commonMain` | `CompositionLocal` providers and the primary `Theme` composable entry point. |

## 4. Impact & Risk Assessment
*   **Breaking Changes:** None. This is purely a documentation update. 
*   **Testing Suggestions:** 
    *   Verify that any automated markdown documentation generators (e.g., Dokka, MkDocs) correctly parse the newly added directory trees and code blocks in `ARCHITECTURE.md`.