### PR TITLE
feat(ScrollView): add auto-hide and draggable scroll indicators

### DIFF
--- a/compose/src/commonMain/kotlin/framework/cortena/ui/layout/ScrollView.kt
+++ b/compose/src/commonMain/kotlin/framework/cortena/ui/layout/ScrollView.kt
@@ -4,10 +4,15 @@
  */
 package framework.cortena.ui.layout
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,8 +28,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -40,6 +50,9 @@ import framework.cortena.ui.geometry.Orientation
 import framework.cortena.ui.layout.internal.BounceOverscrollEffect
 import framework.cortena.ui.shape.CapsuleShape
 import framework.cortena.ui.theme.LocalColors
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 enum class ScrollIndicatorPosition {
     Start,
@@ -69,6 +82,8 @@ fun ScrollView(
     indicatorShape: Shape = CapsuleShape(),
     indicatorPadding: Dp = 2.dp,
     indicatorPosition: ScrollIndicatorPosition = ScrollIndicatorPosition.End,
+    autoHideIndicator: Boolean = true,
+    draggableIndicator: Boolean = true,
 
     // Callbacks
     onScrolled: ((scrollValue: Int, maxScrollValue: Int) -> Unit)? = null,
@@ -156,6 +171,8 @@ fun ScrollView(
                 shape = indicatorShape,
                 padding = indicatorPadding,
                 position = indicatorPosition,
+                autoHide = autoHideIndicator,
+                draggable = draggableIndicator,
             )
         }
     }
@@ -171,6 +188,8 @@ private fun ScrollIndicator(
     shape: Shape,
     padding: Dp,
     position: ScrollIndicatorPosition,
+    autoHide: Boolean,
+    draggable: Boolean,
 ) {
     val density = LocalDensity.current
     val minIndicatorSize = with(density) { 48.dp.toPx() }
@@ -200,27 +219,120 @@ private fun ScrollIndicator(
             0f
         }
 
-    val indicatorModifier =
-        if (orientation == Orientation.Vertical) {
-            val indicatorHeight = (viewportSize * indicatorRatio).coerceAtLeast(minIndicatorSize)
-            val trackSize = viewportSize - indicatorHeight
-            val indicatorOffset = scrollFraction * trackSize
+    val indicatorSizePx =
+        (viewportSize * indicatorRatio).coerceAtLeast(minIndicatorSize)
+    val trackSizePx = (viewportSize - indicatorSizePx).coerceAtLeast(0f)
+    val targetOffsetPx = scrollFraction * trackSizePx
 
-            Modifier.padding(padding)
-                .width(thickness)
-                .height(with(density) { indicatorHeight.toDp() })
-                .graphicsLayer { translationY = indicatorOffset }
+    // Indicator position is mapped 1:1 to scroll. We deliberately do NOT spring-smooth this — any
+    // easing here makes the indicator visibly lag behind the content during fast scrolls.
+    val scope = rememberCoroutineScope()
+    var isDragging by remember { mutableStateOf(false) }
+    val isDraggingState = rememberUpdatedState(isDragging)
+
+    // Thickness scale animates up to IndicatorDragScale while the user is dragging the indicator,
+    // confirming the active interaction with a slight spring overshoot.
+    val thicknessScale = remember { Animatable(1f) }
+    LaunchedEffect(isDragging) {
+        thicknessScale.animateTo(
+            targetValue = if (isDragging) IndicatorDragScale else 1f,
+            animationSpec =
+                spring(
+                    stiffness = Spring.StiffnessMediumLow,
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                ),
+        )
+    }
+
+    // Auto-hide. Visible whenever the scroll value or drag state is active. Fades out after a
+    // short idle period. Pulled to 1f instantly on activity so the response feels immediate.
+    val alphaAnim = remember { Animatable(if (autoHide) 0f else 1f) }
+    if (autoHide) {
+        LaunchedEffect(scrollState, isDragging) {
+            snapshotFlow { scrollState.value to isDragging }
+                .collectLatest { _ ->
+                    // Show
+                    scope.launch {
+                        alphaAnim.snapTo(1f)
+                    }
+                    // Schedule hide unless dragging
+                    if (!isDraggingState.value) {
+                        delay(IndicatorIdleHideDelayMillis)
+                        if (!isDraggingState.value) {
+                            alphaAnim.animateTo(
+                                targetValue = 0f,
+                                animationSpec = tween(durationMillis = IndicatorFadeDurationMillis),
+                            )
+                        }
+                    }
+                }
+        }
+    }
+
+    // Drag-to-scroll. Tap and drag on the indicator translates pointer delta along the track and
+    // applies it to scrollState. Map ratio: trackSizePx → scrollState.maxValue.
+    val dragModifier =
+        if (draggable && trackSizePx > 0f) {
+            Modifier.pointerInput(orientation, trackSizePx, scrollState) {
+                detectDragGestures(
+                    onDragStart = {
+                        isDragging = true
+                        scope.launch { alphaAnim.snapTo(1f) }
+                    },
+                    onDragEnd = { isDragging = false },
+                    onDragCancel = { isDragging = false },
+                    onDrag = { _, dragAmount ->
+                        val deltaPx =
+                            if (orientation == Orientation.Vertical) dragAmount.y else dragAmount.x
+                        val ratio = scrollState.maxValue.toFloat() / trackSizePx
+                        val scrollDelta = (deltaPx * ratio).toInt()
+                        if (scrollDelta != 0) {
+                            scope.launch {
+                                scrollState.scrollTo(
+                                    (scrollState.value + scrollDelta).coerceIn(
+                                        0,
+                                        scrollState.maxValue,
+                                    )
+                                )
+                            }
+                        }
+                    },
+                )
+            }
         } else {
-            val indicatorWidth = (viewportSize * indicatorRatio).coerceAtLeast(minIndicatorSize)
-            val indicatorOffset = scrollFraction * (viewportSize - indicatorWidth)
+            Modifier
+        }
 
+    val baseIndicatorModifier =
+        if (orientation == Orientation.Vertical) {
             Modifier.padding(padding)
-                .height(thickness)
-                .width(with(density) { indicatorWidth.toDp() })
-                .graphicsLayer { translationX = indicatorOffset }
+                .width(thickness * thicknessScale.value)
+                .height(with(density) { indicatorSizePx.toDp() })
+                .graphicsLayer {
+                    translationY = targetOffsetPx
+                    alpha = alphaAnim.value
+                }
+        } else {
+            Modifier.padding(padding)
+                .height(thickness * thicknessScale.value)
+                .width(with(density) { indicatorSizePx.toDp() })
+                .graphicsLayer {
+                    translationX = targetOffsetPx
+                    alpha = alphaAnim.value
+                }
         }
 
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = alignment) {
-        Box(modifier = indicatorModifier.clip(shape).background(color, shape))
+        Box(
+            modifier =
+                baseIndicatorModifier
+                    .clip(shape)
+                    .background(color, shape)
+                    .then(dragModifier)
+        )
     }
 }
+
+private const val IndicatorIdleHideDelayMillis: Long = 1500L
+private const val IndicatorFadeDurationMillis: Int = 220
+private const val IndicatorDragScale: Float = 2f

--- a/docs/components/ScrollView.md
+++ b/docs/components/ScrollView.md
@@ -1,6 +1,6 @@
 # ScrollView
 
-`ScrollView` is Cortena's scrollable container with bounce overscroll and an automatic scroll indicator.
+`ScrollView` is Cortena's scrollable container with bounce overscroll and a smart scroll indicator that auto-hides, animates, and supports direct dragging.
 
 !!! warning "Known Limitation With ScrollView"
 
@@ -19,14 +19,15 @@
 
 ## Concept
 
-`ScrollView` wraps content in a scrollable region that supports both vertical and horizontal orientations. When the user scrolls past the edges, the content bounces with a spring-back animation instead of the default Android glow/stretch effect.
+`ScrollView` wraps content in a scrollable region that supports both vertical and horizontal orientations. When the user scrolls past the edges, the content bounces with a spring-back animation instead of the default Android glow/stretch effect. Pulling the overscroll past a threshold while still holding triggers an auto-release that springs the content back on its own.
 
-A thin capsule-shaped scroll indicator appears automatically when content overflows, proportionally sized to the viewport-to-content ratio.
+A thin capsule-shaped scroll indicator appears automatically when content overflows, proportionally sized to the viewport-to-content ratio. It tracks the scroll position 1:1 for a fully responsive feel, fades out shortly after scrolling stops, and the user can grab it directly to scrub through long content.
 
 Key behaviors:
 
-- **Bounce overscroll**: content shifts with a 0.3× resistance factor during drag, then springs back on release.
-- **Scroll indicator**: auto-sized, auto-positioned, and hidden when content fits without scrolling.
+- **Bounce overscroll**: content shifts with rubber-band resistance during drag, then springs back on release. Auto-releases when pulled past the threshold.
+- **Auto-hide**: the indicator fades out after the user stops interacting and reappears immediately on the next scroll or drag.
+- **Draggable indicator**: tap and drag the indicator to scrub through content. Drag tracks the finger 1:1 so scrubbing feels precise. The indicator visibly thickens while held to confirm the active interaction.
 - **Callbacks**: optional listeners for scroll position, top-reached, and bottom-reached events.
 
 ## API Reference
@@ -47,6 +48,8 @@ fun ScrollView(
     indicatorShape: Shape = CapsuleShape(),
     indicatorPadding: Dp = 2.dp,
     indicatorPosition: ScrollIndicatorPosition = ScrollIndicatorPosition.End,
+    autoHideIndicator: Boolean = true,
+    draggableIndicator: Boolean = true,
     onScrolled: ((scrollValue: Int, maxScrollValue: Int) -> Unit)? = null,
     onReachedTop: (() -> Unit)? = null,
     onReachedBottom: (() -> Unit)? = null,
@@ -61,25 +64,27 @@ enum class ScrollIndicatorPosition {
 
 ### Parameters
 
-| Name                  | Data Type                 | Description                                                          |
-| --------------------- | ------------------------- | -------------------------------------------------------------------- |
-| `modifier`            | `Modifier`                | Standard Compose modifier.                                           |
-| `orientation`         | `Orientation`             | Scroll direction. Default: `Orientation.Vertical`.                   |
-| `scrollState`         | `ScrollState`             | Externally hoisted scroll state. Default: `rememberScrollState()`.   |
-| `enabled`             | `Boolean`                 | Enables or disables scrolling. Default: `true`.                      |
-| `reverseLayout`       | `Boolean`                 | Reverses the scroll direction. Default: `false`.                     |
-| `flingBehavior`       | `FlingBehavior`           | Fling physics. Default: platform default via `ScrollableDefaults`.   |
-| `contentPadding`      | `PaddingValues`           | Inner padding applied to the scrollable content. Default: `0.dp`.    |
-| `showScrollIndicator` | `Boolean`                 | Shows/hides the scroll indicator. Default: `true`.                   |
-| `indicatorThickness`  | `Dp`                      | Thickness of the indicator bar. Default: `3.dp`.                     |
-| `indicatorColor`      | `Color`                   | Color of the indicator. Default: `outline` token from `LocalColors`. |
-| `indicatorShape`      | `Shape`                   | Shape of the indicator. Default: `CapsuleShape()`.                   |
-| `indicatorPadding`    | `Dp`                      | Padding around the indicator. Default: `2.dp`.                       |
-| `indicatorPosition`   | `ScrollIndicatorPosition` | Indicator placement (`Start` or `End`). Default: `End`.              |
-| `onScrolled`          | `((Int, Int) -> Unit)?`   | Called with `(scrollValue, maxScrollValue)` on every scroll change.  |
-| `onReachedTop`        | `(() -> Unit)?`           | Called when scroll position reaches the top (value == 0).            |
-| `onReachedBottom`     | `(() -> Unit)?`           | Called when scroll position reaches the bottom (value == maxValue).  |
-| `content`             | `@Composable () -> Unit`  | The scrollable content.                                              |
+| Name                  | Data Type                 | Description                                                                              |
+| --------------------- | ------------------------- | ---------------------------------------------------------------------------------------- |
+| `modifier`            | `Modifier`                | Standard Compose modifier.                                                               |
+| `orientation`         | `Orientation`             | Scroll direction. Default: `Orientation.Vertical`.                                       |
+| `scrollState`         | `ScrollState`             | Externally hoisted scroll state. Default: `rememberScrollState()`.                       |
+| `enabled`             | `Boolean`                 | Enables or disables scrolling. Default: `true`.                                          |
+| `reverseLayout`       | `Boolean`                 | Reverses the scroll direction. Default: `false`.                                         |
+| `flingBehavior`       | `FlingBehavior`           | Fling physics. Default: platform default via `ScrollableDefaults`.                       |
+| `contentPadding`      | `PaddingValues`           | Inner padding applied to the scrollable content. Default: `0.dp`.                        |
+| `showScrollIndicator` | `Boolean`                 | Shows/hides the scroll indicator. Default: `true`.                                       |
+| `indicatorThickness`  | `Dp`                      | Thickness of the indicator bar. Default: `3.dp`.                                         |
+| `indicatorColor`      | `Color`                   | Color of the indicator. Default: `outline` token from `LocalColors`.                     |
+| `indicatorShape`      | `Shape`                   | Shape of the indicator. Default: `CapsuleShape()`.                                       |
+| `indicatorPadding`    | `Dp`                      | Padding around the indicator. Default: `2.dp`.                                           |
+| `indicatorPosition`   | `ScrollIndicatorPosition` | Indicator placement (`Start` or `End`). Default: `End`.                                  |
+| `autoHideIndicator`   | `Boolean`                 | When `true`, the indicator fades out after a short idle period. Default: `true`.         |
+| `draggableIndicator`  | `Boolean`                 | When `true`, the indicator can be grabbed and dragged to scrub content. Default: `true`. |
+| `onScrolled`          | `((Int, Int) -> Unit)?`   | Called with `(scrollValue, maxScrollValue)` on every scroll change.                      |
+| `onReachedTop`        | `(() -> Unit)?`           | Called when scroll position reaches the top (value == 0).                                |
+| `onReachedBottom`     | `(() -> Unit)?`           | Called when scroll position reaches the bottom (value == maxValue).                      |
+| `content`             | `@Composable () -> Unit`  | The scrollable content.                                                                  |
 
 ### Example
 
@@ -137,5 +142,31 @@ ScrollView(
     Column {
         repeat(50) { Text("Item $it") }
     }
+}
+```
+
+### Always-Visible Indicator
+
+Disable auto-hide if you want a persistent indicator (for example, a debug screen or a panel where the indicator doubles as a visual scale):
+
+```kotlin
+ScrollView(
+    modifier = Modifier.fillMaxSize(),
+    autoHideIndicator = false,
+) {
+    Column { repeat(50) { Text("Item $it") } }
+}
+```
+
+### Disable Drag-to-Scrub
+
+If you do not want the indicator to be interactive (for example, on a read-only preview), turn dragging off:
+
+```kotlin
+ScrollView(
+    modifier = Modifier.fillMaxSize(),
+    draggableIndicator = false,
+) {
+    Column { repeat(50) { Text("Item $it") } }
 }
 ```


### PR DESCRIPTION
Add two new configurable parameters for scroll indicator control: autoHideIndicator and draggableIndicator. Implement auto-hide logic with 1500ms idle delay and 220ms fade animation, plus drag-to-scroll gesture with 1:1 scroll mapping and visual drag feedback. Update all relevant documentation including API reference, concept descriptions, and usage examples for the new features.