### PR TITLE
feat: add motion design system and update docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,15 +6,20 @@
 graph TD
     catalog["`:catalog`"] --> compose["`:compose`"]
     compose --> shape["`:shape`"]
+    compose --> motion["`:motion`"]
     compose --> foundation["`:foundation`"]
     shape --> foundation
+    motion --> foundation
 ```
 
-`:catalog` depends on `:compose` (and transitively `:shape` and `:foundation`).
-`:compose` depends on `:shape` and `:foundation`. Both are exposed via `api(...)` so consumers do
-not need a separate dependency on either.
+`:catalog` depends on `:compose` (and transitively `:shape`, `:motion`, and `:foundation`).
+`:compose` depends on `:shape`, `:motion`, and `:foundation`. All three are exposed via `api(...)`
+so consumers do not need separate dependencies.
 `:shape` depends on `:foundation` and on `compose.runtime` + `compose.ui`. It can be consumed
 standalone by Compose-based apps that only need the shape system.
+`:motion` depends on `:foundation` and on `compose.runtime` + `compose.animation.core`. It can be
+consumed standalone by Compose-based apps that want to adopt Cortena's motion language without
+pulling the rest of the framework.
 `:foundation` has zero external dependencies — pure Kotlin.
 
 ## Modules
@@ -43,6 +48,9 @@ foundation/src/commonMain/kotlin/framework/cortena/ui/
 │   ├── CornerStyle.kt           # Circular vs Continuous
 │   └── internal/
 │       └── CornerBuilder.kt     # squircle bezier solver (kotlin.math only)
+├── motion/
+│   ├── DurationTokens.kt     # raw ms Long values: Fast=150, Medium=250, Slow=450
+│   └── EasingTokens.kt       # cubic-bezier coefficients as Float quartets
 ├── size/
 │   ├── SizeToken.kt          # ExtraSmall / Small / Medium / Large / ExtraLarge
 │   └── SizeScale.kt          # raw dp Float values per tier
@@ -80,11 +88,32 @@ shape/src/commonMain/kotlin/framework/cortena/ui/shape/
     └── ShapeOutline.kt       # bridge from ContinuousCurvature → Compose Outline / Path
 ```
 
+### `:motion`
+
+**Centralized motion language.** Depends on `:foundation` and on `compose.runtime` +
+`compose.animation.core`. Holds the shared spring presets, duration tiers, and easing curves
+consumed by every interactive component. Components must read motion specs through
+`LocalMotion.current` rather than constructing `spring(...)` or `tween(...)` calls inline.
+
+The split mirrors `:shape`: pure Kotlin tokens at the foundation level (raw `Long` ms,
+`Float` cubic-bezier coefficients), Compose adapters in `:motion` that turn those tokens into
+`SpringSpec`, `Easing`, and `AnimationSpec` instances.
+
+```
+motion/src/commonMain/kotlin/framework/cortena/ui/motion/
+├── SpringPresets.kt          # Snappy / Smooth / Gentle as SpringSpec<Float>
+├── MotionDuration.kt         # DurationTokens narrowed to Int for tween()
+├── MotionEasing.kt           # EasingTokens lifted to Compose Easing
+├── Motion.kt                 # aggregate carrier consumed via LocalMotion
+└── LocalMotion.kt            # staticCompositionLocalOf<Motion> with default DefaultMotion
+```
+
 ### `:compose`
 
-Compose wrappers and theme layer. Depends on `:foundation` and `:shape`.
+Compose wrappers and theme layer. Depends on `:foundation`, `:shape`, and `:motion`.
 Converts foundation tokens (`Long`/`Float`) to Compose types (`Color`, `TextUnit`, `Dp`).
-Provides `Theme { }` entry point via `CompositionLocalProvider`.
+Provides `Theme { }` entry point via `CompositionLocalProvider`, which also injects
+`LocalMotion` for the spring / duration / easing language.
 
 The module is split into `commonMain` (multiplatform-ready) and `androidMain` (Android-specific platform code).
 
@@ -116,7 +145,7 @@ compose/src/commonMain/kotlin/framework/cortena/ui/
 │   ├── AppBar.kt            # top app bar slot
 │   ├── Body.kt              # edge-to-edge root wrapper
 │   ├── SafeArea.kt          # system insets padding
-│   └── ScrollView.kt        # scrollable content container
+│   └── ScrollView.kt        # scrollable container with bounce overscroll, auto-hiding and draggable indicator
 └── theme/
     ├── ColorExtensions.kt         # ColorToken.value() helpers
     ├── LocalProviders.kt          # CompositionLocal definitions
@@ -143,7 +172,7 @@ compose/src/androidMain/kotlin/framework/cortena/ui/
 
 ### `:catalog`
 
-Showcase app. Depends on `:compose` (and transitively `:shape` + `:foundation`).
+Showcase app. Depends on `:compose` (and transitively `:shape`, `:motion`, `:foundation`).
 Used to develop and visually verify all components in a live environment.
 
 ```
@@ -162,7 +191,7 @@ catalog/src/main/java/app/cortena/ui/catalog/
 
 ### CompositionLocal Providers
 
-The theme layer exposes five `CompositionLocal` keys, each provided by the `Theme()` composable:
+The theme layer exposes the following `CompositionLocal` keys, each provided by the `Theme()` composable:
 
 | Key                 | Type         | Default             | Purpose                                       |
 | ------------------- | ------------ | ------------------- | --------------------------------------------- |
@@ -171,6 +200,8 @@ The theme layer exposes five `CompositionLocal` keys, each provided by the `Them
 | `LocalContentColor` | `Color?`     | `null`              | Inherited foreground color (scoped by parent) |
 | `LocalTypography`   | `Typography` | `DefaultTypography` | Semantic text style scales                    |
 | `LocalSpacing`      | `Spacing`    | `Spacing`           | 4dp-grid spacing tokens                       |
+| `LocalSizeToken`    | `SizeToken`  | `SizeToken.Medium`  | Global component size tier                    |
+| `LocalMotion`       | `Motion`     | `DefaultMotion`     | Spring presets, duration tiers, easing curves |
 
 ### ThemeMode Resolution
 
@@ -207,6 +238,22 @@ val resolvedColor = if (customColor.isSpecified) customColor else Color(colors.s
 
 This allows per-instance color overrides while defaulting to theme-aware semantic roles.
 
+### Motion
+
+All animation specs originate from `LocalMotion.current`. Components do not hardcode `spring(...)` or `tween(...)` numbers — they pick a preset:
+
+```kotlin
+val motion = LocalMotion.current
+
+animateFloatAsState(target, animationSpec = motion.snappy)             // tight feedback
+animateDpAsState(targetDp, animationSpec = motion.smooth)              // content shift
+tween<Color>(motion.medium, easing = motion.standardEasing)            // deterministic fade
+```
+
+The presets carry the design language. Spring tier covers `snappy` (tight feedback), `smooth` (general motion), and `gentle` (large overlays). Duration tier covers `fast` (150ms), `medium` (250ms), and `slow` (450ms). Easings cover `standardEasing`, `emphasizedEasing`, and `linearEasing`.
+
+The single documented exception is raw gesture-physics primitives — `DampedAnimation` and `InteractiveHighlight` — where each track (position, velocity, press progress, scale-x, scale-y) needs its own bespoke `dampingRatio` / `stiffness` / `visibilityThreshold` tuple to feel right under continuous pointer input. Any new bespoke spec inside one of these primitives must include an inline comment explaining why a preset cannot be used.
+
 ### Shadow System
 
 The `componentShadow` modifier renders drop shadows that remain visible during scale animations (unlike standard `Modifier.shadow` which clips at the original bounds). This is critical for interactive components like Toggle and Slider indicators.
@@ -221,6 +268,7 @@ Component documentation is maintained in `docs/components/` following a standard
 | `Body.md`        | Edge-to-edge root wrapper    |
 | `Button.md`      | Interactive button           |
 | `ContentView.md` | Android activity entry point |
+| `Motion.md`      | Motion language reference    |
 | `SafeArea.md`    | System insets padding        |
 | `ScrollView.md`  | Scrollable container         |
 | `Separator.md`   | Visual divider line          |
@@ -246,6 +294,14 @@ The squircle math itself is pure Kotlin and lives in `:foundation`. The Compose-
 shape system — for example a CortenaOS dynamic-island overlay or a third-party Compose app —
 can depend on `:shape` without pulling the rest of CortenaUI. This also keeps the boundary
 between framework-agnostic geometry and Compose types explicit and enforceable.
+
+**Why a separate `:motion` module?**
+Same reasoning as `:shape`. The raw duration ms and cubic-bezier coefficients live in
+`:foundation` (pure Kotlin, framework-agnostic). The Compose adapters that turn those into
+`SpringSpec`, `Easing`, and `AnimationSpec` instances live in `:motion` so consumers — for
+example a CortenaOS system surface or a third-party Compose app adopting Cortena's motion
+language — can depend on `:motion` without the rest of the framework. The split also keeps
+`:foundation` free of any `compose.animation.core` types.
 
 **Why a separate `:compose` module?**
 When ROM integration comes, `:foundation` goes into the system image. Compose

--- a/docs/components/Motion.md
+++ b/docs/components/Motion.md
@@ -1,0 +1,114 @@
+# Motion
+
+CortenaUI's motion language. A small, opinionated set of spring presets, duration tiers, and easing curves shared by every interactive component. Read at runtime through `LocalMotion.current`.
+
+## Concept
+
+Motion is a design token, just like color or spacing. Components do not invent their own animation specs — they pick a preset that matches the role of the motion. This keeps the feel of the library coherent across components and across the surface as a whole.
+
+The system distinguishes two kinds of motion:
+
+- **Spring presets** are the default for any motion that originates from user input or follows physical causality — press response, content shift, panel reveal. Spring fits because the user feels the physics.
+- **Tween durations + easing** are reserved for transitions that must be deterministic — alpha fade, color crossfade, indicator hide. Tween fits because the timing is what matters, not the physics.
+
+Components must read both through `LocalMotion.current` and never call `spring(...)` or `tween(...)` with hardcoded numbers. The single documented exception is raw gesture-physics primitives (`DampedAnimation`, `InteractiveHighlight`), which need bespoke per-track specs to feel right under continuous pointer input.
+
+## API Reference
+
+```kotlin
+@Immutable
+class Motion {
+    val snappy: SpringSpec<Float>
+    val smooth: SpringSpec<Float>
+    val gentle: SpringSpec<Float>
+
+    val fast: Int     // 150 ms
+    val medium: Int   // 250 ms
+    val slow: Int     // 450 ms
+
+    val standardEasing: Easing
+    val emphasizedEasing: Easing
+    val linearEasing: Easing
+}
+
+val DefaultMotion: Motion
+val LocalMotion: ProvidableCompositionLocal<Motion>
+```
+
+### Spring Presets
+
+| Preset   | Stiffness                   | Damping ratio | Use case                                                |
+| -------- | --------------------------- | ------------- | ------------------------------------------------------- |
+| `snappy` | `Spring.StiffnessHigh`      | No bouncy     | Tight UI feedback (press, toggle thumb, indicator drag) |
+| `smooth` | `Spring.StiffnessMediumLow` | No bouncy     | General content shift, panel reveal, item move          |
+| `gentle` | `Spring.StiffnessLow`       | No bouncy     | Large overlays, dialog enter / exit, page transition    |
+
+All three default to `DampingRatioNoBouncy`. Components that want a tactile overshoot — for example a button releasing from a press — should construct a custom `spring()` from these stiffness values plus a higher damping ratio (`DampingRatioMediumBouncy`) rather than redefining the stiffness.
+
+### Duration Tokens
+
+| Token    | Value | Use case                                          |
+| -------- | ----- | ------------------------------------------------- |
+| `fast`   | 150   | Tap feedback, small fades, color shifts           |
+| `medium` | 250   | Standard fades, indicator hide, content crossfade |
+| `slow`   | 450   | Emphasis transitions, dialog scrim                |
+
+Durations are exposed as `Int` (ms) so they pass directly into `tween()`.
+
+### Easings
+
+| Easing             | Curve                  | Use case                        |
+| ------------------ | ---------------------- | ------------------------------- |
+| `standardEasing`   | `(0.4, 0.0, 0.2, 1.0)` | Default for most fades          |
+| `emphasizedEasing` | `(0.2, 0.0, 0.0, 1.0)` | Decelerated arrivals            |
+| `linearEasing`     | linear                 | Color / alpha that must be even |
+
+## Examples
+
+Spring-driven content motion:
+
+```kotlin
+val motion = LocalMotion.current
+val offset by animateDpAsState(targetOffset, animationSpec = motion.smooth)
+```
+
+Tap feedback that should feel instant:
+
+```kotlin
+val motion = LocalMotion.current
+val scale by animateFloatAsState(if (pressed) 0.96f else 1f, animationSpec = motion.snappy)
+```
+
+Deterministic alpha fade:
+
+```kotlin
+val motion = LocalMotion.current
+val alpha = remember { Animatable(0f) }
+LaunchedEffect(visible) {
+    alpha.animateTo(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(motion.medium, easing = motion.standardEasing),
+    )
+}
+```
+
+Custom tactile overshoot — the documented pattern for exceptions like indicator drag-thicken:
+
+```kotlin
+val motion = LocalMotion.current
+val scaleSpring =
+    spring<Float>(
+        stiffness = motion.smooth.stiffness,
+        dampingRatio = Spring.DampingRatioMediumBouncy,
+    )
+```
+
+## Override
+
+Provide a custom `Motion` to `Theme()` if you want to tune the language for a specific surface — for example a "reduce motion" accessibility mode that swaps every spring for a faster, less bouncy variant:
+
+```kotlin
+Theme(motion = MyReducedMotion) {
+    // ...
+}
+```

--- a/docs/components/Theme.md
+++ b/docs/components/Theme.md
@@ -4,7 +4,7 @@
 
 ## Concept
 
-Any component written to Cortena specifications, such as `Text` or `SafeArea`, reads its color, spacing, or shape properties via:
+Any component written to Cortena specifications, such as `Text` or `SafeArea`, reads its color, spacing, motion, or shape properties via:
 
 - `LocalIsDark.current`
 - `LocalColors.current`
@@ -12,6 +12,7 @@ Any component written to Cortena specifications, such as `Text` or `SafeArea`, r
 - `LocalFontFamily.current`
 - `LocalSpacing.current`
 - `LocalSizeToken.current`
+- `LocalMotion.current`
 
 The function of `Theme` is to provide these actual values at the top of the hierarchy (root node). `ContentView` already calls this internally, so you rarely need to call it directly unless you are inside a preview function (`@Preview`) of pure compose.
 
@@ -25,6 +26,7 @@ fun Theme(
     typography: Typography = DefaultTypography,
     fontFamily: FontFamily? = null,
     sizeToken: SizeToken = SizeToken.Medium,
+    motion: Motion = DefaultMotion,
     content: @Composable () -> Unit
 )
 ```
@@ -38,4 +40,5 @@ fun Theme(
 | `typography` | `Typography`             | Overrides the adjusted _font scale_. Default: `DefaultTypography`.                                                                       |
 | `fontFamily` | `FontFamily?`            | Custom font family applied to all `Text` components. If `null`, uses the system default font (`FontFamily.Default`).                     |
 | `sizeToken`  | `SizeToken`              | Sets the global component size tier. All sized components inherit this. Default: `SizeToken.Medium`.                                     |
+| `motion`     | `Motion`                 | Spring presets, durations, and easings consumed by every interactive component. Default: `DefaultMotion`. See [Motion](Motion.md).       |
 | `content`    | `@Composable () -> Unit` | Lambda for your child Composable function placed under the umbrella of this theme.                                                       |


### PR DESCRIPTION
- add new `:motion` module with spring presets, duration tokens, and easing curves
- update core `Theme` composable to accept motion parameter and provide `LocalMotion`
- create full Motion.md documentation covering usage, API, and best practices
- update `ARCHITECTURE.md` to document new module dependencies and structure
- enforce consistent component animations by requiring `LocalMotion.current` instead of hardcoded specs