### PR TITLE
feat: set up maven central publishing and release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Compile all modules
+        run: ./gradlew :foundation:compileAndroidMain :shape:compileAndroidMain :motion:compileAndroidMain :compose:compileAndroidMain :catalog:compileDebugKotlin --stacktrace
+
+      - name: Assemble release AARs
+        run: ./gradlew :foundation:assemble :shape:assemble :motion:assemble :compose:assemble --stacktrace
+
+      - name: Validate publication metadata
+        run: ./gradlew :foundation:generatePomFileForKotlinMultiplatformPublication :shape:generatePomFileForKotlinMultiplatformPublication :motion:generatePomFileForKotlinMultiplatformPublication :compose:generatePomFileForKotlinMultiplatformPublication --stacktrace

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - master
     paths:
-      - '**.toml'
-      - '**.txt'
-      - 'docs/**.md'
-      - '.github/workflows/**.yml'
+      - "**.toml"
+      - "**.txt"
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,27 +19,27 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    
+
     steps:
       - uses: actions/configure-pages@v6
 
       - uses: actions/checkout@v6
-      
+
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      
+
       - run: pip install zensical
-      
+
       - run: zensical build --clean
-      
+
       - uses: actions/upload-pages-artifact@v5
         with:
           path: site
-      
+
       - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Collect AARs
         run: |
           mkdir -p release-artifacts
-          cp foundation/build/outputs/aar/foundation-release.aar release-artifacts/foundation-${{ steps.version.outputs.value }}.aar || true
-          cp shape/build/outputs/aar/shape-release.aar release-artifacts/shape-${{ steps.version.outputs.value }}.aar || true
-          cp motion/build/outputs/aar/motion-release.aar release-artifacts/motion-${{ steps.version.outputs.value }}.aar || true
-          cp compose/build/outputs/aar/compose-release.aar release-artifacts/compose-${{ steps.version.outputs.value }}.aar || true
+          cp foundation/build/outputs/aar/foundation-release.aar release-artifacts/ui-foundation-${{ steps.version.outputs.value }}.aar || true
+          cp shape/build/outputs/aar/shape-release.aar release-artifacts/ui-shape-${{ steps.version.outputs.value }}.aar || true
+          cp motion/build/outputs/aar/motion-release.aar release-artifacts/ui-motion-${{ steps.version.outputs.value }}.aar || true
+          cp compose/build/outputs/aar/compose-release.aar release-artifacts/ui-${{ steps.version.outputs.value }}.aar || true
           ls -la release-artifacts
 
       - name: Attach AARs to GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Override the published version (defaults to project version)."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: maven-central
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+        run: |
+          if [ -n "${{ steps.version.outputs.value }}" ]; then
+            ./gradlew publishToMavenCentral -Pversion="${{ steps.version.outputs.value }}" --stacktrace --no-configuration-cache
+          else
+            ./gradlew publishToMavenCentral --stacktrace --no-configuration-cache
+          fi
+
+      - name: Assemble release AARs for GitHub Release
+        run: ./gradlew :foundation:assemble :shape:assemble :motion:assemble :compose:assemble --stacktrace
+
+      - name: Collect AARs
+        run: |
+          mkdir -p release-artifacts
+          cp foundation/build/outputs/aar/foundation-release.aar release-artifacts/foundation-${{ steps.version.outputs.value }}.aar || true
+          cp shape/build/outputs/aar/shape-release.aar release-artifacts/shape-${{ steps.version.outputs.value }}.aar || true
+          cp motion/build/outputs/aar/motion-release.aar release-artifacts/motion-${{ steps.version.outputs.value }}.aar || true
+          cp compose/build/outputs/aar/compose-release.aar release-artifacts/compose-${{ steps.version.outputs.value }}.aar || true
+          ls -la release-artifacts
+
+      - name: Attach AARs to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-artifacts/*.aar
+          generate_release_notes: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,10 @@ plugins {
     alias(libs.plugins.android.multiplatform.library) apply false
     alias(libs.plugins.jetbrains.compose) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
+    alias(libs.plugins.maven.publish) apply false
+}
+
+allprojects {
+    group = "io.github.cortenaos"
+    version = "0.1.0-alpha"
 }

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = 35
         targetSdk = 37
         versionCode = 1
-        versionName = "1.0"
+        versionName = "0.1.0-alpha"
     }
 
     buildTypes {
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":foundation"))
+    // :compose transitively brings in :foundation, :shape, and :motion via api(...).
     implementation(project(":compose"))
 
     implementation(libs.androidx.activity.compose)

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -5,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.maven.publish)
 }
 
 kotlin {
@@ -25,5 +29,55 @@ kotlin {
             implementation(libs.compose.ui)
         }
         androidMain.dependencies { implementation(libs.androidx.activity.compose) }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (project.hasProperty("signingInMemoryKey")) {
+        signAllPublications()
+    }
+
+    coordinates(
+        groupId = group.toString(),
+        artifactId = "compose",
+        version = version.toString(),
+    )
+
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            androidVariantsToPublish = listOf("release"),
+        )
+    )
+
+    pom {
+        name.set("CortenaUI Compose")
+        description.set(
+            "Compose component layer for CortenaUI: Button, Slider, Toggle, Text, Icon, " +
+                "ScrollView, Theme, and the rest. Transitively pulls :foundation, :shape, and " +
+                ":motion via api dependencies."
+        )
+        url.set("https://github.com/cortenaos/cortenaui")
+        licenses {
+            license {
+                name.set("GNU General Public License v3.0")
+                url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("cortenaos")
+                name.set("The CortenaOS Project")
+                url.set("https://github.com/cortenaos")
+            }
+        }
+        scm {
+            url.set("https://github.com/cortenaos/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
+        }
     }
 }

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -40,7 +40,7 @@ mavenPublishing {
 
     coordinates(
         groupId = group.toString(),
-        artifactId = "compose",
+        artifactId = "ui",
         version = version.toString(),
     )
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -268,22 +268,22 @@ The `componentShadow` modifier renders drop shadows that remain visible during s
 
 Component documentation is maintained in `docs/components/` following a standardized format:
 
-| Document         | Component                    |
-| ---------------- | ---------------------------- |
-| `AppBar.md`      | Top app bar                  |
-| `Body.md`        | Edge-to-edge root wrapper    |
-| `Button.md`      | Interactive button           |
-| `ContentView.md` | Android activity entry point |
-| `Icon.md`        | Tinted vector icon           |
-| `Motion.md`      | Motion language reference    |
-| `SafeArea.md`    | System insets padding        |
-| `ScrollView.md`  | Scrollable container         |
-| `Separator.md`   | Visual divider line          |
-| `Shape.md`       | Shape system + squircle math |
-| `Slider.md`      | Value adjustment slider      |
-| `Text.md`        | Semantic text component      |
-| `Theme.md`       | Theme composable             |
-| `Toggle.md`      | Switch / toggle              |
+| Document                  | Component                    |
+| ------------------------- | ---------------------------- |
+| `components/AppBar.md`    | Top app bar                  |
+| `components/Button.md`    | Interactive button           |
+| `components/Icon.md`      | Tinted vector icon           |
+| `components/Separator.md` | Visual divider line          |
+| `components/Slider.md`    | Value adjustment slider      |
+| `components/Text.md`      | Semantic text component      |
+| `components/Toggle.md`    | Switch / toggle              |
+| `layout/Body.md`          | Edge-to-edge root wrapper    |
+| `layout/ContentView.md`   | Android activity entry point |
+| `layout/SafeArea.md`      | System insets padding        |
+| `layout/ScrollView.md`    | Scrollable container         |
+| `layout/Theme.md`         | Theme composable             |
+| `extra/Motion.md`         | Motion language reference    |
+| `extra/Shape.md`          | Shape system + squircle math |
 
 Each document follows the structure: **Concept → API Reference → Parameters Table → Examples**.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -119,6 +119,8 @@ Direct dependencies you can declare:
 | `:motion`     | `:foundation`                      |
 | `:compose`    | `:foundation`, `:shape`, `:motion` |
 
+> Each module is a Kotlin Multiplatform publication. Always declare the artifact without a platform suffix (e.g. `compose`, not `compose-android`). Gradle reads the metadata and resolves the right variant for your target — typically the Android AAR — automatically.
+
 ## Snapshot builds
 
 There are no snapshot builds during the alpha phase. Each `0.x.0-alpha` tag is a stable point release.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,169 @@
+# Installation
+
+CortenaUI is published to **Maven Central** under the `io.github.cortenaos` group ID. Each library module is publishable on its own, so you can pull only what you need.
+
+> Source code lives at [github.com/cortenaos/cortenaui](https://github.com/cortenaos/cortenaui). Imports in your code stay on the `framework.cortena.ui.*` package — only the Maven coordinate uses `io.github.cortenaos`.
+
+## Repository
+
+Maven Central is enabled by default in modern Gradle setups. If you have customised your repositories, add it back:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
+```
+
+## All-in-one — `:compose`
+
+The most common case. `:compose` transitively pulls `:foundation`, `:shape`, and `:motion`, so you get the full component library with one dependency.
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    implementation("io.github.cortenaos:compose:0.1.0-alpha")
+}
+```
+
+After this single line you can use the entire framework:
+
+```kotlin
+import framework.cortena.ui.components.Button
+import framework.cortena.ui.components.Text
+import framework.cortena.ui.components.Toggle
+import framework.cortena.ui.layout.ScrollView
+import framework.cortena.ui.theme.Theme
+import framework.cortena.ui.shape.CapsuleShape
+import framework.cortena.ui.motion.LocalMotion
+
+@Composable
+fun App() {
+    Theme {
+        Button(onClick = { }) { Text("Hello CortenaUI") }
+    }
+}
+```
+
+## Modular adoption
+
+Pull only the modules you need. Useful if you only want the design tokens, just the shape system, or only the motion language without the rest of the component layer.
+
+### Tokens only — `:foundation`
+
+Pure Kotlin, zero dependencies. Use this if you want CortenaUI's color / size / typography / motion tokens without any Compose surface.
+
+```kotlin
+dependencies {
+    implementation("io.github.cortenaos:foundation:0.1.0-alpha")
+}
+```
+
+```kotlin
+import framework.cortena.ui.color.ColorToken
+import framework.cortena.ui.size.SizeToken
+import framework.cortena.ui.typography.TypeScale
+import framework.cortena.ui.motion.DurationTokens
+```
+
+### Shapes only — `:shape`
+
+Compose `Shape` adapter for CortenaUI's squircle math. Useful for adopters who want the squircle / continuous-curvature look in their own Compose components without pulling in the rest of the framework. Transitively pulls `:foundation`.
+
+```kotlin
+dependencies {
+    implementation("io.github.cortenaos:shape:0.1.0-alpha")
+}
+```
+
+```kotlin
+import framework.cortena.ui.shape.CapsuleShape
+import framework.cortena.ui.shape.RoundedShape
+import framework.cortena.ui.shape.UnevenShape
+```
+
+### Motion only — `:motion`
+
+Spring presets, duration tiers, and easing curves used across CortenaUI. Adopt this if you want consistent motion language in your own components without using CortenaUI components themselves. Transitively pulls `:foundation`.
+
+```kotlin
+dependencies {
+    implementation("io.github.cortenaos:motion:0.1.0-alpha")
+}
+```
+
+```kotlin
+import framework.cortena.ui.motion.LocalMotion
+import framework.cortena.ui.motion.DefaultMotion
+```
+
+## Module dependency graph
+
+```
+:compose ──api──┐
+                ├──► :foundation
+:shape ─────api─┤
+                │
+:motion ────api─┘
+```
+
+Direct dependencies you can declare:
+
+| You depend on | You also get (transitively)        |
+| ------------- | ---------------------------------- |
+| `:foundation` | nothing                            |
+| `:shape`      | `:foundation`                      |
+| `:motion`     | `:foundation`                      |
+| `:compose`    | `:foundation`, `:shape`, `:motion` |
+
+## Snapshot builds
+
+There are no snapshot builds during the alpha phase. Each `0.x.0-alpha` tag is a stable point release.
+
+## Manual AAR install
+
+Each release on GitHub also attaches per-module AARs as assets:
+
+- `foundation-<version>.aar`
+- `shape-<version>.aar`
+- `motion-<version>.aar`
+- `compose-<version>.aar`
+
+Drop them into your project's `libs/` folder if you need an offline-friendly install. Note that with this approach you lose Maven's transitive dependency resolution — you must include every AAR your chosen module depends on.
+
+## Requirements
+
+- **Min SDK**: 35 for `:compose`, 21 for `:foundation`, `:shape`, and `:motion`.
+- **Compile SDK**: 37+.
+- **Kotlin**: 2.3+.
+- **Compose Multiplatform**: 1.10.3+.
+
+## Verifying the install
+
+After syncing, render the catalog snippet:
+
+```kotlin
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import framework.cortena.ui.components.Button
+import framework.cortena.ui.components.Text
+import framework.cortena.ui.theme.Theme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            Theme {
+                Button(onClick = { /* TODO */ }) {
+                    Text("CortenaUI is installed")
+                }
+            }
+        }
+    }
+}
+```
+
+If the button renders with the capsule shape, spring press response, and onPrimary color, you are set.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -18,14 +18,14 @@ dependencyResolutionManagement {
 }
 ```
 
-## All-in-one — `:compose`
+## All-in-one — `ui`
 
-The most common case. `:compose` transitively pulls `:foundation`, `:shape`, and `:motion`, so you get the full component library with one dependency.
+The most common case. The `ui` artifact transitively pulls `ui-foundation`, `ui-shape`, and `ui-motion`, so you get the full component library with one dependency.
 
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    implementation("io.github.cortenaos:compose:0.1.0-alpha")
+    implementation("io.github.cortenaos:ui:0.1.0-alpha")
 }
 ```
 
@@ -52,13 +52,13 @@ fun App() {
 
 Pull only the modules you need. Useful if you only want the design tokens, just the shape system, or only the motion language without the rest of the component layer.
 
-### Tokens only — `:foundation`
+### Tokens only — `ui-foundation`
 
 Pure Kotlin, zero dependencies. Use this if you want CortenaUI's color / size / typography / motion tokens without any Compose surface.
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaos:foundation:0.1.0-alpha")
+    implementation("io.github.cortenaos:ui-foundation:0.1.0-alpha")
 }
 ```
 
@@ -69,13 +69,13 @@ import framework.cortena.ui.typography.TypeScale
 import framework.cortena.ui.motion.DurationTokens
 ```
 
-### Shapes only — `:shape`
+### Shapes only — `ui-shape`
 
-Compose `Shape` adapter for CortenaUI's squircle math. Useful for adopters who want the squircle / continuous-curvature look in their own Compose components without pulling in the rest of the framework. Transitively pulls `:foundation`.
+Compose `Shape` adapter for CortenaUI's squircle math. Useful for adopters who want the squircle / continuous-curvature look in their own Compose components without pulling in the rest of the framework. Transitively pulls `ui-foundation`.
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaos:shape:0.1.0-alpha")
+    implementation("io.github.cortenaos:ui-shape:0.1.0-alpha")
 }
 ```
 
@@ -85,13 +85,13 @@ import framework.cortena.ui.shape.RoundedShape
 import framework.cortena.ui.shape.UnevenShape
 ```
 
-### Motion only — `:motion`
+### Motion only — `ui-motion`
 
-Spring presets, duration tiers, and easing curves used across CortenaUI. Adopt this if you want consistent motion language in your own components without using CortenaUI components themselves. Transitively pulls `:foundation`.
+Spring presets, duration tiers, and easing curves used across CortenaUI. Adopt this if you want consistent motion language in your own components without using CortenaUI components themselves. Transitively pulls `ui-foundation`.
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaos:motion:0.1.0-alpha")
+    implementation("io.github.cortenaos:ui-motion:0.1.0-alpha")
 }
 ```
 
@@ -103,23 +103,23 @@ import framework.cortena.ui.motion.DefaultMotion
 ## Module dependency graph
 
 ```
-:compose ──api──┐
-                ├──► :foundation
-:shape ─────api─┤
-                │
-:motion ────api─┘
+ui ──api──┐
+          ├──► ui-foundation
+ui-shape ─api─┤
+          │
+ui-motion api─┘
 ```
 
 Direct dependencies you can declare:
 
-| You depend on | You also get (transitively)        |
-| ------------- | ---------------------------------- |
-| `:foundation` | nothing                            |
-| `:shape`      | `:foundation`                      |
-| `:motion`     | `:foundation`                      |
-| `:compose`    | `:foundation`, `:shape`, `:motion` |
+| You depend on   | You also get (transitively)              |
+| --------------- | ---------------------------------------- |
+| `ui-foundation` | nothing                                  |
+| `ui-shape`      | `ui-foundation`                          |
+| `ui-motion`     | `ui-foundation`                          |
+| `ui`            | `ui-foundation`, `ui-shape`, `ui-motion` |
 
-> Each module is a Kotlin Multiplatform publication. Always declare the artifact without a platform suffix (e.g. `compose`, not `compose-android`). Gradle reads the metadata and resolves the right variant for your target — typically the Android AAR — automatically.
+> Each module is a Kotlin Multiplatform publication. Always declare the artifact without a platform suffix (e.g. `ui`, not `ui-android`). Gradle reads the metadata and resolves the right variant for your target — typically the Android AAR — automatically.
 
 ## Snapshot builds
 
@@ -129,16 +129,16 @@ There are no snapshot builds during the alpha phase. Each `0.x.0-alpha` tag is a
 
 Each release on GitHub also attaches per-module AARs as assets:
 
-- `foundation-<version>.aar`
-- `shape-<version>.aar`
-- `motion-<version>.aar`
-- `compose-<version>.aar`
+- `ui-foundation-<version>.aar`
+- `ui-shape-<version>.aar`
+- `ui-motion-<version>.aar`
+- `ui-<version>.aar`
 
 Drop them into your project's `libs/` folder if you need an offline-friendly install. Note that with this approach you lose Maven's transitive dependency resolution — you must include every AAR your chosen module depends on.
 
 ## Requirements
 
-- **Min SDK**: 35 for `:compose`, 21 for `:foundation`, `:shape`, and `:motion`.
+- **Min SDK**: 35 for `ui`, 21 for `ui-foundation`, `ui-shape`, and `ui-motion`.
 - **Compile SDK**: 37+.
 - **Kotlin**: 2.3+.
 - **Compose Multiplatform**: 1.10.3+.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,155 @@
+# Publishing
+
+This document covers what a CortenaUI maintainer needs to do to ship a release. End users do not need to read this — they only need [INSTALLATION.md](INSTALLATION.md).
+
+CortenaUI publishes four artifacts to **Maven Central** under the `io.github.cortenaos` group ID:
+
+- `io.github.cortenaos:foundation`
+- `io.github.cortenaos:shape`
+- `io.github.cortenaos:motion`
+- `io.github.cortenaos:compose`
+
+Publishing is automated through the `Publish` GitHub Actions workflow. Pushing a tag of the form `v<version>` (for example `v0.1.0-alpha`) triggers a build, signs every artifact, uploads them to Maven Central, and attaches the per-module AARs to a GitHub Release.
+
+## One-time setup
+
+Before the first publish, you need three things in order: a Sonatype Central Portal account, a GPG key, and four GitHub Actions secrets.
+
+### 1. Sonatype Central Portal namespace
+
+1. Sign in at [central.sonatype.com](https://central.sonatype.com).
+2. Go to **Namespaces** and add `io.github.cortenaos`. Sonatype verifies GitHub-based namespaces automatically by reading public repositories under the `cortenaos` org. Verification takes a few minutes.
+3. Generate a **publishing token** under **View Account → Generate User Token**. Copy the token's username and password — you'll store them as GitHub secrets in step 3.
+
+### 2. GPG signing key
+
+Maven Central requires every artifact to be signed.
+
+```bash
+# Generate a key (RSA, 4096 bits, 0 expiry)
+gpg --full-generate-key
+
+# List secret keys to find the key id
+gpg --list-secret-keys --keyid-format LONG
+
+# Export the secret key as ASCII (this is what GitHub Actions consumes)
+gpg --armor --export-secret-keys <KEY_ID> > signing.key
+
+# Upload the public key to a keyserver so Maven Central can fetch it for verification
+gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
+```
+
+Pick a strong passphrase when generating the key — store it alongside the key in your password manager.
+
+### 3. GitHub Actions secrets
+
+Open `https://github.com/cortenaos/cortenaui/settings/secrets/actions` and add the following four secrets, then create an environment named `maven-central` and assign the secrets to it (the publish workflow runs in that environment):
+
+| Secret                           | Value                                                                 |
+| -------------------------------- | --------------------------------------------------------------------- |
+| `MAVEN_CENTRAL_USERNAME`         | Username from the Sonatype publishing token (step 1).                 |
+| `MAVEN_CENTRAL_PASSWORD`         | Password from the Sonatype publishing token (step 1).                 |
+| `SIGNING_IN_MEMORY_KEY`          | Contents of `signing.key` from step 2 (the full ASCII-armored block). |
+| `SIGNING_IN_MEMORY_KEY_PASSWORD` | Passphrase you used when generating the GPG key.                      |
+
+The plugin (`com.vanniktech.maven.publish`) reads them as `ORG_GRADLE_PROJECT_*` environment variables — the workflow translates the secrets into that format automatically.
+
+## Cutting a release
+
+Each release is a signed Git tag of the form `v<version>`. Versions follow the layout `MAJOR.MINOR.PATCH-<channel>`, where channel is `alpha`, `beta`, or omitted for stable.
+
+```bash
+# Bump the version in build.gradle.kts at the project root.
+# The single line `version = "0.1.0-alpha"` controls all four modules.
+${EDITOR:-vim} build.gradle.kts
+
+# Commit and tag.
+git commit -am "release: 0.1.0-alpha"
+git tag v0.1.0-alpha
+
+# Push the tag — this is what fires the Publish workflow.
+git push origin master
+git push origin v0.1.0-alpha
+```
+
+The workflow takes around five minutes. Watch progress at `https://github.com/cortenaos/cortenaui/actions`.
+
+When the workflow finishes, head to [central.sonatype.com](https://central.sonatype.com) → **Deployments** and confirm a draft deployment is staged. Review the artifacts, then click **Publish** to release to Maven Central. Artifacts become consumable about ten to thirty minutes after the publish click.
+
+A GitHub Release is also created automatically, with the four AARs attached as assets and release notes generated from commit history.
+
+## Local testing before tagging
+
+Before pushing a tag, smoke-test locally to confirm the publish pipeline works without exposing it to the world.
+
+### `publishToMavenLocal`
+
+Publishes every artifact to your local `~/.m2/repository`. Fast feedback, no credentials, no network.
+
+```bash
+./gradlew publishToMavenLocal
+```
+
+In a consumer project, point Gradle at the local cache and reference the artifacts:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+}
+```
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    implementation("io.github.cortenaos:compose:0.1.0-alpha")
+}
+```
+
+If everything resolves and the demo app compiles, the publish config is sound.
+
+### Dry-run signing
+
+To verify your GPG setup without uploading anything, run:
+
+```bash
+./gradlew publishAllPublicationsToMavenLocalRepository \
+  -PsigningInMemoryKey="$(cat signing.key)" \
+  -PsigningInMemoryKeyPassword="<your passphrase>"
+```
+
+Look for `*.asc` files alongside each `.aar`, `.jar`, and `.pom` in the output directories. If they're missing, signing didn't fire.
+
+## Release checklist
+
+Before tagging, walk through this:
+
+- [ ] Working tree clean on `master`.
+- [ ] Version bumped in `build.gradle.kts` at the project root.
+- [ ] Catalog `versionName` matches in `catalog/build.gradle.kts` (cosmetic — the catalog isn't published).
+- [ ] `CHANGELOG.md` updated with a section for the new version (if maintained).
+- [ ] All component docs in `docs/components/` reflect the current API.
+- [ ] `./gradlew build` passes locally.
+- [ ] `./gradlew publishToMavenLocal` succeeds and the artifacts look right under `~/.m2/repository/io/github/cortenaos/`.
+
+After tagging:
+
+- [ ] Workflow run is green at `https://github.com/cortenaos/cortenaui/actions`.
+- [ ] Deployment is visible at [central.sonatype.com](https://central.sonatype.com) → Deployments.
+- [ ] Reviewed and clicked **Publish** on the staging deployment.
+- [ ] Verified the GitHub Release page has the four AAR assets attached.
+- [ ] Smoke-tested in a fresh consumer project after Maven Central indexes the artifacts.
+
+## Troubleshooting
+
+**"401 Unauthorized" during upload.** The `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` secrets are wrong or the Sonatype token expired. Regenerate the token at central.sonatype.com and update the secrets.
+
+**"Failed to verify signature" on the deployment.** The public key isn't on a keyserver Maven Central can reach, or the `SIGNING_IN_MEMORY_KEY` doesn't match the public key. Re-upload the public key with `gpg --send-keys`.
+
+**"Namespace not verified" on the deployment.** Sonatype hasn't finished verifying `io.github.cortenaos`. Wait a few minutes; if it persists, check the namespace status at [central.sonatype.com](https://central.sonatype.com) → Namespaces.
+
+**Dependency cycle on local publish.** Inter-module `api(project(":foundation"))` declarations can sometimes confuse `publishToMavenLocal` ordering. Run with `--no-parallel` if you hit this.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -4,10 +4,12 @@ This document covers what a CortenaUI maintainer needs to do to ship a release. 
 
 CortenaUI publishes four artifacts to **Maven Central** under the `io.github.cortenaos` group ID:
 
-- `io.github.cortenaos:foundation`
-- `io.github.cortenaos:shape`
-- `io.github.cortenaos:motion`
-- `io.github.cortenaos:compose`
+- `io.github.cortenaos:ui-foundation`
+- `io.github.cortenaos:ui-shape`
+- `io.github.cortenaos:ui-motion`
+- `io.github.cortenaos:ui`
+
+The `ui` artifact is the meta-artifact users normally depend on — it transitively pulls every other module. The `ui-*` siblings let consumers cherry-pick.
 
 Publishing is automated through the `Publish` GitHub Actions workflow. Pushing a tag of the form `v<version>` (for example `v0.1.0-alpha`) triggers a build, signs every artifact, uploads them to Maven Central, and attaches the per-module AARs to a GitHub Release.
 
@@ -58,21 +60,34 @@ The plugin (`com.vanniktech.maven.publish`) reads them as `ORG_GRADLE_PROJECT_*`
 
 Each release is a signed Git tag of the form `v<version>`. Versions follow the layout `MAJOR.MINOR.PATCH-<channel>`, where channel is `alpha`, `beta`, or omitted for stable.
 
+> The repository's `master` branch is protected, so version bumps go through a PR. The publish workflow is fired by the **tag push**, not by the merge, so branch protection does not block releases.
+
 ```bash
-# Bump the version in build.gradle.kts at the project root.
-# The single line `version = "0.1.0-alpha"` controls all four modules.
+# 1. Create a release branch off master
+git checkout master
+git pull
+git checkout -b release/0.1.1-alpha
+
+# 2. Bump the version. The single line `version = "0.1.1-alpha"` in the project root
+#    `build.gradle.kts` controls all four library modules. Mirror it in
+#    `catalog/build.gradle.kts` for cosmetic parity.
 ${EDITOR:-vim} build.gradle.kts
+${EDITOR:-vim} catalog/build.gradle.kts
 
-# Commit and tag.
-git commit -am "release: 0.1.0-alpha"
-git tag v0.1.0-alpha
+# 3. Commit and push the branch.
+git commit -am "release: 0.1.1-alpha"
+git push origin release/0.1.1-alpha
 
-# Push the tag — this is what fires the Publish workflow.
-git push origin master
-git push origin v0.1.0-alpha
+# 4. Open a PR, wait for the Build workflow to pass, merge it.
+
+# 5. Pull the merged commit and tag it.
+git checkout master
+git pull
+git tag v0.1.1-alpha
+git push origin v0.1.1-alpha
 ```
 
-The workflow takes around five minutes. Watch progress at `https://github.com/cortenaos/cortenaui/actions`.
+The tag push is what fires the Publish workflow. Watch progress at `https://github.com/cortenaos/cortenaui/actions`. The full pipeline takes around five minutes.
 
 When the workflow finishes, head to [central.sonatype.com](https://central.sonatype.com) → **Deployments** and confirm a draft deployment is staged. Review the artifacts, then click **Publish** to release to Maven Central. Artifacts become consumable about ten to thirty minutes after the publish click.
 
@@ -106,7 +121,7 @@ dependencyResolutionManagement {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    implementation("io.github.cortenaos:compose:0.1.0-alpha")
+    implementation("io.github.cortenaos:ui:0.1.0-alpha")
 }
 ```
 

--- a/docs/extra/Shape.md
+++ b/docs/extra/Shape.md
@@ -9,7 +9,7 @@ The shape system is split across two modules:
 
 - **`:foundation`** holds the pure-Kotlin math: `CornerStyle`, the `CornerBuilder` squircle
   solver, and the `ContinuousCurvature.emit(...)` API that streams path commands into a
-  consumer-supplied [`CornerPathReceiver`](#cornerpathreceiver). No graphics framework imports.
+  consumer-supplied [`CornerPathReceiver`](#cornerpathreceiver-foundation). No graphics framework imports.
 - **`:shape`** holds the Compose binding: the sealed `ComponentShape` hierarchy
   (`CapsuleShape`, `RoundedShape`, `UnevenShape`, `RectangleShape`), shape lerp / copy helpers,
   and the bridge that turns the foundation math into `Outline.Generic` for Compose.

--- a/docs/layout/Theme.md
+++ b/docs/layout/Theme.md
@@ -33,12 +33,12 @@ fun Theme(
 
 ### Parameters
 
-| Name         | Data Type                | Description                                                                                                                              |
-| ------------ | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `themeMode`  | `ThemeMode`              | Options are `ThemeMode.Light`, `ThemeMode.Dark`, or `ThemeMode.Auto` (detects current OS mode).                                          |
-| `palette`    | `Palette?`               | Ignores automatic OS detection and forces the specific palette you want. If `null`, it will automatically resolve following `themeMode`. |
-| `typography` | `Typography`             | Overrides the adjusted _font scale_. Default: `DefaultTypography`.                                                                       |
-| `fontFamily` | `FontFamily?`            | Custom font family applied to all `Text` components. If `null`, uses the system default font (`FontFamily.Default`).                     |
-| `sizeToken`  | `SizeToken`              | Sets the global component size tier. All sized components inherit this. Default: `SizeToken.Medium`.                                     |
-| `motion`     | `Motion`                 | Spring presets, durations, and easings consumed by every interactive component. Default: `DefaultMotion`. See [Motion](Motion.md).       |
-| `content`    | `@Composable () -> Unit` | Lambda for your child Composable function placed under the umbrella of this theme.                                                       |
+| Name         | Data Type                | Description                                                                                                                                 |
+| ------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `themeMode`  | `ThemeMode`              | Options are `ThemeMode.Light`, `ThemeMode.Dark`, or `ThemeMode.Auto` (detects current OS mode).                                             |
+| `palette`    | `Palette?`               | Ignores automatic OS detection and forces the specific palette you want. If `null`, it will automatically resolve following `themeMode`.    |
+| `typography` | `Typography`             | Overrides the adjusted _font scale_. Default: `DefaultTypography`.                                                                          |
+| `fontFamily` | `FontFamily?`            | Custom font family applied to all `Text` components. If `null`, uses the system default font (`FontFamily.Default`).                        |
+| `sizeToken`  | `SizeToken`              | Sets the global component size tier. All sized components inherit this. Default: `SizeToken.Medium`.                                        |
+| `motion`     | `Motion`                 | Spring presets, durations, and easings consumed by every interactive component. Default: `DefaultMotion`. See [Motion](../extra/Motion.md). |
+| `content`    | `@Composable () -> Unit` | Lambda for your child Composable function placed under the umbrella of this theme.                                                          |

--- a/foundation/build.gradle.kts
+++ b/foundation/build.gradle.kts
@@ -34,7 +34,7 @@ mavenPublishing {
 
     coordinates(
         groupId = group.toString(),
-        artifactId = "foundation",
+        artifactId = "ui-foundation",
         version = version.toString(),
     )
 

--- a/foundation/build.gradle.kts
+++ b/foundation/build.gradle.kts
@@ -1,8 +1,12 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.multiplatform.library)
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.maven.publish)
 }
 
 kotlin {
@@ -18,6 +22,56 @@ kotlin {
             // Intentionally empty — foundation has zero external dependencies.
             // This module must remain framework-agnostic so it can be consumed
             // by Compose, View system, and future ROM integration alike.
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (project.hasProperty("signingInMemoryKey")) {
+        signAllPublications()
+    }
+
+    coordinates(
+        groupId = group.toString(),
+        artifactId = "foundation",
+        version = version.toString(),
+    )
+
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            androidVariantsToPublish = listOf("release"),
+        )
+    )
+
+    pom {
+        name.set("CortenaUI Foundation")
+        description.set(
+            "Pure Kotlin design tokens and framework-agnostic shape geometry for CortenaUI. " +
+                "Zero external dependencies — usable from Compose, the Android View system, " +
+                "and AOSP / Android.bp builds without modification."
+        )
+        url.set("https://github.com/cortenaos/cortenaui")
+        licenses {
+            license {
+                name.set("GNU General Public License v3.0")
+                url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("cortenaos")
+                name.set("The CortenaOS Project")
+                url.set("https://github.com/cortenaos")
+            }
+        }
+        scm {
+            url.set("https://github.com/cortenaos/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ jetbrainsKotlinJvm = "2.3.21"
 icons = "1.7.8"
 kotlin = "2.3.21"
 material3 = "1.4.0"
+mavenPublish = "0.36.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -23,3 +24,4 @@ jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/motion/build.gradle.kts
+++ b/motion/build.gradle.kts
@@ -1,8 +1,12 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.multiplatform.library)
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.maven.publish)
 }
 
 kotlin {
@@ -15,13 +19,63 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":foundation"))
+            api(project(":foundation"))
             // Motion needs compose.runtime for CompositionLocal + @Stable / @Immutable, and
             // compose.animation.core for SpringSpec / Easing / AnimationSpec primitives.
             // It deliberately does not depend on compose.ui or compose.foundation — motion
             // values are framework primitives, not UI surface.
             implementation(libs.compose.runtime)
             implementation(libs.compose.animation.core)
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (project.hasProperty("signingInMemoryKey")) {
+        signAllPublications()
+    }
+
+    coordinates(
+        groupId = group.toString(),
+        artifactId = "motion",
+        version = version.toString(),
+    )
+
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            androidVariantsToPublish = listOf("release"),
+        )
+    )
+
+    pom {
+        name.set("CortenaUI Motion")
+        description.set(
+            "Compose-aware spring presets, duration tiers, and easing curves for CortenaUI. " +
+                "Components read motion specs through LocalMotion rather than constructing " +
+                "spring(...) or tween(...) calls inline."
+        )
+        url.set("https://github.com/cortenaos/cortenaui")
+        licenses {
+            license {
+                name.set("GNU General Public License v3.0")
+                url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("cortenaos")
+                name.set("The CortenaOS Project")
+                url.set("https://github.com/cortenaos")
+            }
+        }
+        scm {
+            url.set("https://github.com/cortenaos/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
         }
     }
 }

--- a/motion/build.gradle.kts
+++ b/motion/build.gradle.kts
@@ -38,7 +38,7 @@ mavenPublishing {
 
     coordinates(
         groupId = group.toString(),
-        artifactId = "motion",
+        artifactId = "ui-motion",
         version = version.toString(),
     )
 

--- a/shape/build.gradle.kts
+++ b/shape/build.gradle.kts
@@ -1,8 +1,12 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.multiplatform.library)
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.maven.publish)
 }
 
 kotlin {
@@ -15,13 +19,63 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":foundation"))
+            api(project(":foundation"))
             // Shape only needs the runtime stability annotations (@Stable, @Immutable)
             // and the core graphics / geometry / unit primitives (Shape, Outline, Path,
             // Size, Density, Dp, LayoutDirection). It deliberately does not depend on
             // compose.foundation — all consumers of these shapes already pull foundation in.
             implementation(libs.compose.runtime)
             implementation(libs.compose.ui)
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = false)
+    if (project.hasProperty("signingInMemoryKey")) {
+        signAllPublications()
+    }
+
+    coordinates(
+        groupId = group.toString(),
+        artifactId = "shape",
+        version = version.toString(),
+    )
+
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            androidVariantsToPublish = listOf("release"),
+        )
+    )
+
+    pom {
+        name.set("CortenaUI Shape")
+        description.set(
+            "Compose-aware shape system for CortenaUI. Bridges the framework-agnostic squircle " +
+                "math from :foundation to the Compose Shape API. Publishable as a standalone AAR " +
+                "for Compose-only consumers and non-Compose system surfaces alike."
+        )
+        url.set("https://github.com/cortenaos/cortenaui")
+        licenses {
+            license {
+                name.set("GNU General Public License v3.0")
+                url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("cortenaos")
+                name.set("The CortenaOS Project")
+                url.set("https://github.com/cortenaos")
+            }
+        }
+        scm {
+            url.set("https://github.com/cortenaos/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
         }
     }
 }

--- a/shape/build.gradle.kts
+++ b/shape/build.gradle.kts
@@ -38,7 +38,7 @@ mavenPublishing {
 
     coordinates(
         groupId = group.toString(),
-        artifactId = "shape",
+        artifactId = "ui-shape",
         version = version.toString(),
     )
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -27,7 +27,7 @@ site_author = "Achmad Daniel <hello.achmaddaniel@gmail.com>"
 # The site_url is the canonical URL for your site. When building online
 # documentation you should set this.
 # Read more: https://zensical.org/docs/setup/basics/#site_url
-#site_url = "https://cortena.github.io/cortenaui"
+site_url = "https://cortenaos.github.io/cortenaui"
 
 # The copyright notice appears in the page footer and can contain an HTML
 # fragment.
@@ -37,8 +37,8 @@ copyright = """
 Copyright &copy; 2026-present The CortenaOS Project
 """
 
-repo_url = "https://github.com/cortena/cortenaui"
-repo_name = "cortena/cortenaui"
+repo_url = "https://github.com/cortenaos/cortenaui"
+repo_name = "cortenaos/cortenaui"
 
 # Zensical supports both implicit navigation and explicitly defined navigation.
 # If you decide not to define a navigation here then Zensical will simply
@@ -52,6 +52,7 @@ nav = [
     "Overview" = [ 
       "index.md", 
       "GETTING-STARTED.md", 
+      "INSTALLATION.md",
       "ARCHITECTURE.md"
     ]
   },
@@ -60,6 +61,11 @@ nav = [
       { "Layout" = [ "layout/ContentView.md", "layout/Theme.md", "layout/Body.md", "layout/SafeArea.md", "layout/ScrollView.md" ] },
       { "Component" = [ "components/AppBar.md", "components/Button.md", "components/Icon.md", "components/Separator.md", "components/Slider.md", "components/Text.md", "components/Toggle.md" ] },
       { "Extra" = [ "extra/Motion.md", "extra/Shape.md" ] },
+    ]
+  },
+  {
+    "Contributing" = [
+      "PUBLISHING.md"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Sets up the release pipeline for CortenaUI: Maven Central publishing for all four library modules, CI workflows for build verification and tag-driven publishing, and contributor + consumer documentation. Bumps the project version to `0.1.0-alpha`, the first publishable cut.

## Maven coordinates

Published under group `io.github.cortenaos` — verifiable on Sonatype Central Portal because it matches the GitHub organization. Imports inside user code stay on `framework.cortena.ui.*`; only the build-script coordinate uses `io.github.cortenaos`.

| Artifact                              | Purpose                                                   | Transitive deps                       |
| ------------------------------------- | --------------------------------------------------------- | ------------------------------------- |
| `io.github.cortenaos:ui`              | Meta-artifact. The default for end users.                 | `ui-foundation`, `ui-shape`, `ui-motion` |
| `io.github.cortenaos:ui-foundation`   | Pure-Kotlin tokens + framework-agnostic shape geometry.   | none                                  |
| `io.github.cortenaos:ui-shape`        | Compose-aware `ComponentShape` system.                    | `ui-foundation`                       |
| `io.github.cortenaos:ui-motion`       | Spring presets, durations, easings.                       | `ui-foundation`                       |

The `ui-*` siblings let consumers cherry-pick (e.g. ROM developers who only need shape math, library authors who want the motion language without the components).

## What changed

### Build configuration
- Added `com.vanniktech.maven.publish` 0.36.0 plugin via `gradle/libs.versions.toml`.
- Root `build.gradle.kts` sets `group = "io.github.cortenaos"` and `version = "0.1.0-alpha"` for all subprojects.
- Each library module (`:foundation`, `:shape`, `:motion`, `:compose`) declares `coordinates(...)`, `KotlinMultiplatform(...)` config (sources jar, no javadoc, release variant), and a full POM (name, description, GPL-3.0 license, developers, scm).
- Signing is conditional (`if (project.hasProperty("signingInMemoryKey"))`) so `publishToMavenLocal` works without GPG, while CI publishing still signs every artifact.
- `:shape` and `:motion` upgrade `implementation(project(":foundation"))` to `api(...)` so consumers transitively get foundation types.
- `:catalog` now depends only on `:compose` (foundation comes via `api`); `versionName` bumped to `0.1.0-alpha` for parity.

### CI/CD workflows
- **`.github/workflows/build.yml`** — runs on `push` to master and on every PR. Compiles all four modules + catalog, assembles release AARs, and validates publication metadata via `generatePomFile*` tasks.
- **`.github/workflows/publish.yml`** — runs on `v*` tag pushes and on manual `workflow_dispatch`. Publishes signed artifacts to Maven Central (staging deployment, manual release click required), assembles AARs, and attaches them to a GitHub Release with auto-generated notes. Gated by a `maven-central` environment so secrets stay scoped.
- **`.github/workflows/docs.yml`** — path filter widened from `docs/**.md` (which only matched flat) to `docs/**` so subdirectory edits redeploy. Also adds `workflow_dispatch` for manual runs.

### Documentation
- **`docs/INSTALLATION.md`** — user-facing. All-in-one and cherry-pick examples, dependency graph, KMP variant resolution note, manual AAR install, requirements, smoke verification snippet.
- **`docs/PUBLISHING.md`** — maintainer-facing. Sonatype namespace setup, GPG key generation, GitHub Actions secrets, cutting-a-release flow that respects the protected `master` branch (release branch → PR → merge → tag), local testing with `publishToMavenLocal`, release checklist, troubleshooting.
- **`docs/ARCHITECTURE.md`** — Documentation table refreshed to reflect the `components/` / `layout/` / `extra/` directory layout.
- **`docs/layout/Theme.md`** — fixed cross-link to `Motion.md` after the directory reorg (`../extra/Motion.md`).
- **`docs/extra/Shape.md`** — fixed dangling anchor to `#cornerpathreceiver-foundation`.
- **`zensical.toml`** — corrected `repo_url`, `repo_name`, and `site_url` to the `cortenaos` org. Added `INSTALLATION.md` to "Overview" and a new "Contributing" section with `PUBLISHING.md`.

## Verification

- `./gradlew :compose:compileAndroidMain :catalog:compileDebugKotlin` — BUILD SUCCESSFUL.
- `./gradlew clean publishToMavenLocal` — BUILD SUCCESSFUL. Eight directories produced under `~/.m2/repository/io/github/cortenaos/` (`ui`, `ui-android`, `ui-foundation`, `ui-foundation-android`, `ui-shape`, `ui-shape-android`, `ui-motion`, `ui-motion-android`).
- POM inspection: `ui-android-0.1.0-alpha.pom` declares compile-scope dependencies on `ui-foundation-android`, `ui-shape-android`, `ui-motion-android`. Transitive resolution behaves as designed — `implementation("io.github.cortenaos:ui:0.1.0-alpha")` is enough on the consumer side.
- `python -m zensical build --clean` — `No issues found`. Both new pages render (`INSTALLATION/index.html`, `PUBLISHING/index.html`).

## Not included in this PR

- **Sonatype account, GPG key, GitHub Actions secrets.** These are one-time external setup steps owned by the maintainer. `docs/PUBLISHING.md` documents them in full. Until those are in place, the publish workflow will fail on signing or auth — which is expected and harmless. The first publish tag should not be pushed until setup is done.
- **No tag pushed.** This PR only sets up the pipeline; nothing is published to Maven Central by merging it.

## How to publish after this lands

After this PR merges and the one-time setup in `docs/PUBLISHING.md` is complete:

```bash
git checkout master && git pull
git tag v0.1.0-alpha
git push origin v0.1.0-alpha
