### PR TITLE
chore: migrate namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Every element is built with a clear contract for how it responds — to touch, t
 
 ## Documentation
 
-Full documentation is available at [cortena.github.io/cortenaui](https://cortena.github.io/cortenaui).
+Full documentation is available at [cortenaui.github.io/cortenaui](https://cortenaui.github.io/cortenaui).
 
 Built with [Zensical](https://github.com/zensical/zensical).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,6 @@ plugins {
 }
 
 allprojects {
-    group = "io.github.cortenaos"
+    group = "io.github.cortenaui"
     version = "0.1.0-alpha"
 }

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -59,7 +59,7 @@ mavenPublishing {
                 "ScrollView, Theme, and the rest. Transitively pulls :foundation, :shape, and " +
                 ":motion via api dependencies."
         )
-        url.set("https://github.com/cortenaos/cortenaui")
+        url.set("https://github.com/cortenaui/cortenaui")
         licenses {
             license {
                 name.set("GNU General Public License v3.0")
@@ -69,15 +69,15 @@ mavenPublishing {
         }
         developers {
             developer {
-                id.set("cortenaos")
+                id.set("cortenaui")
                 name.set("The CortenaOS Project")
-                url.set("https://github.com/cortenaos")
+                url.set("https://github.com/cortenaui")
             }
         }
         scm {
-            url.set("https://github.com/cortenaos/cortenaui")
-            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
-            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
+            url.set("https://github.com/cortenaui/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaui/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaui/cortenaui.git")
         }
     }
 }

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,8 +1,8 @@
 # Installation
 
-CortenaUI is published to **Maven Central** under the `io.github.cortenaos` group ID. Each library module is publishable on its own, so you can pull only what you need.
+CortenaUI is published to **Maven Central** under the `io.github.cortenaui` group ID. Each library module is publishable on its own, so you can pull only what you need.
 
-> Source code lives at [github.com/cortenaos/cortenaui](https://github.com/cortenaos/cortenaui). Imports in your code stay on the `framework.cortena.ui.*` package — only the Maven coordinate uses `io.github.cortenaos`.
+> Source code lives at [github.com/cortenaui/cortenaui](https://github.com/cortenaui/cortenaui). Imports in your code stay on the `framework.cortena.ui.*` package — only the Maven coordinate uses `io.github.cortenaui`.
 
 ## Repository
 
@@ -25,7 +25,7 @@ The most common case. The `ui` artifact transitively pulls `ui-foundation`, `ui-
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    implementation("io.github.cortenaos:ui:0.1.0-alpha")
+    implementation("io.github.cortenaui:ui:0.1.0-alpha")
 }
 ```
 
@@ -58,7 +58,7 @@ Pure Kotlin, zero dependencies. Use this if you want CortenaUI's color / size / 
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaos:ui-foundation:0.1.0-alpha")
+    implementation("io.github.cortenaui:ui-foundation:0.1.0-alpha")
 }
 ```
 
@@ -75,7 +75,7 @@ Compose `Shape` adapter for CortenaUI's squircle math. Useful for adopters who w
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaos:ui-shape:0.1.0-alpha")
+    implementation("io.github.cortenaui:ui-shape:0.1.0-alpha")
 }
 ```
 
@@ -91,7 +91,7 @@ Spring presets, duration tiers, and easing curves used across CortenaUI. Adopt t
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaos:ui-motion:0.1.0-alpha")
+    implementation("io.github.cortenaui:ui-motion:0.1.0-alpha")
 }
 ```
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -2,12 +2,12 @@
 
 This document covers what a CortenaUI maintainer needs to do to ship a release. End users do not need to read this — they only need [INSTALLATION.md](INSTALLATION.md).
 
-CortenaUI publishes four artifacts to **Maven Central** under the `io.github.cortenaos` group ID:
+CortenaUI publishes four artifacts to **Maven Central** under the `io.github.cortenaui` group ID:
 
-- `io.github.cortenaos:ui-foundation`
-- `io.github.cortenaos:ui-shape`
-- `io.github.cortenaos:ui-motion`
-- `io.github.cortenaos:ui`
+- `io.github.cortenaui:ui-foundation`
+- `io.github.cortenaui:ui-shape`
+- `io.github.cortenaui:ui-motion`
+- `io.github.cortenaui:ui`
 
 The `ui` artifact is the meta-artifact users normally depend on — it transitively pulls every other module. The `ui-*` siblings let consumers cherry-pick.
 
@@ -20,7 +20,7 @@ Before the first publish, you need three things in order: a Sonatype Central Por
 ### 1. Sonatype Central Portal namespace
 
 1. Sign in at [central.sonatype.com](https://central.sonatype.com).
-2. Go to **Namespaces** and add `io.github.cortenaos`. Sonatype verifies GitHub-based namespaces automatically by reading public repositories under the `cortenaos` org. Verification takes a few minutes.
+2. Go to **Namespaces** and add `io.github.cortenaui`. Sonatype verifies GitHub-based namespaces automatically by reading public repositories under the `cortenaui` org. Verification takes a few minutes.
 3. Generate a **publishing token** under **View Account → Generate User Token**. Copy the token's username and password — you'll store them as GitHub secrets in step 3.
 
 ### 2. GPG signing key
@@ -45,7 +45,7 @@ Pick a strong passphrase when generating the key — store it alongside the key 
 
 ### 3. GitHub Actions secrets
 
-Open `https://github.com/cortenaos/cortenaui/settings/secrets/actions` and add the following four secrets, then create an environment named `maven-central` and assign the secrets to it (the publish workflow runs in that environment):
+Open `https://github.com/cortenaui/cortenaui/settings/secrets/actions` and add the following four secrets, then create an environment named `maven-central` and assign the secrets to it (the publish workflow runs in that environment):
 
 | Secret                           | Value                                                                 |
 | -------------------------------- | --------------------------------------------------------------------- |
@@ -87,7 +87,7 @@ git tag v0.1.1-alpha
 git push origin v0.1.1-alpha
 ```
 
-The tag push is what fires the Publish workflow. Watch progress at `https://github.com/cortenaos/cortenaui/actions`. The full pipeline takes around five minutes.
+The tag push is what fires the Publish workflow. Watch progress at `https://github.com/cortenaui/cortenaui/actions`. The full pipeline takes around five minutes.
 
 When the workflow finishes, head to [central.sonatype.com](https://central.sonatype.com) → **Deployments** and confirm a draft deployment is staged. Review the artifacts, then click **Publish** to release to Maven Central. Artifacts become consumable about ten to thirty minutes after the publish click.
 
@@ -121,7 +121,7 @@ dependencyResolutionManagement {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    implementation("io.github.cortenaos:ui:0.1.0-alpha")
+    implementation("io.github.cortenaui:ui:0.1.0-alpha")
 }
 ```
 
@@ -149,11 +149,11 @@ Before tagging, walk through this:
 - [ ] `CHANGELOG.md` updated with a section for the new version (if maintained).
 - [ ] All component docs in `docs/components/` reflect the current API.
 - [ ] `./gradlew build` passes locally.
-- [ ] `./gradlew publishToMavenLocal` succeeds and the artifacts look right under `~/.m2/repository/io/github/cortenaos/`.
+- [ ] `./gradlew publishToMavenLocal` succeeds and the artifacts look right under `~/.m2/repository/io/github/cortenaui/`.
 
 After tagging:
 
-- [ ] Workflow run is green at `https://github.com/cortenaos/cortenaui/actions`.
+- [ ] Workflow run is green at `https://github.com/cortenaui/cortenaui/actions`.
 - [ ] Deployment is visible at [central.sonatype.com](https://central.sonatype.com) → Deployments.
 - [ ] Reviewed and clicked **Publish** on the staging deployment.
 - [ ] Verified the GitHub Release page has the four AAR assets attached.
@@ -165,6 +165,6 @@ After tagging:
 
 **"Failed to verify signature" on the deployment.** The public key isn't on a keyserver Maven Central can reach, or the `SIGNING_IN_MEMORY_KEY` doesn't match the public key. Re-upload the public key with `gpg --send-keys`.
 
-**"Namespace not verified" on the deployment.** Sonatype hasn't finished verifying `io.github.cortenaos`. Wait a few minutes; if it persists, check the namespace status at [central.sonatype.com](https://central.sonatype.com) → Namespaces.
+**"Namespace not verified" on the deployment.** Sonatype hasn't finished verifying `io.github.cortenaui`. Wait a few minutes; if it persists, check the namespace status at [central.sonatype.com](https://central.sonatype.com) → Namespaces.
 
 **Dependency cycle on local publish.** Inter-module `api(project(":foundation"))` declarations can sometimes confuse `publishToMavenLocal` ordering. Run with `--no-parallel` if you hit this.

--- a/foundation/build.gradle.kts
+++ b/foundation/build.gradle.kts
@@ -53,7 +53,7 @@ mavenPublishing {
                 "Zero external dependencies — usable from Compose, the Android View system, " +
                 "and AOSP / Android.bp builds without modification."
         )
-        url.set("https://github.com/cortenaos/cortenaui")
+        url.set("https://github.com/cortenaui/cortenaui")
         licenses {
             license {
                 name.set("GNU General Public License v3.0")
@@ -63,15 +63,15 @@ mavenPublishing {
         }
         developers {
             developer {
-                id.set("cortenaos")
+                id.set("cortenaui")
                 name.set("The CortenaOS Project")
-                url.set("https://github.com/cortenaos")
+                url.set("https://github.com/cortenaui")
             }
         }
         scm {
-            url.set("https://github.com/cortenaos/cortenaui")
-            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
-            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
+            url.set("https://github.com/cortenaui/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaui/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaui/cortenaui.git")
         }
     }
 }

--- a/motion/build.gradle.kts
+++ b/motion/build.gradle.kts
@@ -57,7 +57,7 @@ mavenPublishing {
                 "Components read motion specs through LocalMotion rather than constructing " +
                 "spring(...) or tween(...) calls inline."
         )
-        url.set("https://github.com/cortenaos/cortenaui")
+        url.set("https://github.com/cortenaui/cortenaui")
         licenses {
             license {
                 name.set("GNU General Public License v3.0")
@@ -67,15 +67,15 @@ mavenPublishing {
         }
         developers {
             developer {
-                id.set("cortenaos")
+                id.set("cortenaui")
                 name.set("The CortenaOS Project")
-                url.set("https://github.com/cortenaos")
+                url.set("https://github.com/cortenaui")
             }
         }
         scm {
-            url.set("https://github.com/cortenaos/cortenaui")
-            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
-            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
+            url.set("https://github.com/cortenaui/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaui/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaui/cortenaui.git")
         }
     }
 }

--- a/shape/build.gradle.kts
+++ b/shape/build.gradle.kts
@@ -57,7 +57,7 @@ mavenPublishing {
                 "math from :foundation to the Compose Shape API. Publishable as a standalone AAR " +
                 "for Compose-only consumers and non-Compose system surfaces alike."
         )
-        url.set("https://github.com/cortenaos/cortenaui")
+        url.set("https://github.com/cortenaui/cortenaui")
         licenses {
             license {
                 name.set("GNU General Public License v3.0")
@@ -67,15 +67,15 @@ mavenPublishing {
         }
         developers {
             developer {
-                id.set("cortenaos")
+                id.set("cortenaui")
                 name.set("The CortenaOS Project")
-                url.set("https://github.com/cortenaos")
+                url.set("https://github.com/cortenaui")
             }
         }
         scm {
-            url.set("https://github.com/cortenaos/cortenaui")
-            connection.set("scm:git:git://github.com/cortenaos/cortenaui.git")
-            developerConnection.set("scm:git:ssh://git@github.com/cortenaos/cortenaui.git")
+            url.set("https://github.com/cortenaui/cortenaui")
+            connection.set("scm:git:git://github.com/cortenaui/cortenaui.git")
+            developerConnection.set("scm:git:ssh://git@github.com/cortenaui/cortenaui.git")
         }
     }
 }

--- a/zensical.toml
+++ b/zensical.toml
@@ -27,7 +27,7 @@ site_author = "Achmad Daniel <hello.achmaddaniel@gmail.com>"
 # The site_url is the canonical URL for your site. When building online
 # documentation you should set this.
 # Read more: https://zensical.org/docs/setup/basics/#site_url
-site_url = "https://cortenaos.github.io/cortenaui"
+site_url = "https://cortenaui.github.io/cortenaui"
 
 # The copyright notice appears in the page footer and can contain an HTML
 # fragment.
@@ -37,8 +37,8 @@ copyright = """
 Copyright &copy; 2026-present The CortenaOS Project
 """
 
-repo_url = "https://github.com/cortenaos/cortenaui"
-repo_name = "cortenaos/cortenaui"
+repo_url = "https://github.com/cortenaui/cortenaui"
+repo_name = "cortenaui/cortenaui"
 
 # Zensical supports both implicit navigation and explicitly defined navigation.
 # If you decide not to define a navigation here then Zensical will simply


### PR DESCRIPTION
## Summary

Migrates the project from `cortenaos` to `cortenaui` GitHub org and from `io.github.cortenaos` to `io.github.cortenaui` Maven Central namespace. The first publish at the new namespace will be `v0.1.0-alpha` (matching what was published at the old namespace, since no API changes happened in between).

## What changed

### Build coordinates
- Group ID `io.github.cortenaos` → `io.github.cortenaui` in root `build.gradle.kts`.
- POM `url`, `developers.id`, `developers.url`, `scm.*` updated to `cortenaui` in all four library modules (`foundation`, `shape`, `motion`, `compose`).

### Repository references
- `zensical.toml`: `repo_url`, `repo_name`, `site_url` updated to `cortenaui` org.
- `README.md`: docs link typo fixed (`cortena.github.io` → `cortenaui.github.io`).

### Documentation
- `docs/INSTALLATION.md`: all `io.github.cortenaos:*` coordinates and repo links rewritten.
- `docs/PUBLISHING.md`: namespace, secrets URL path, deployment URL all updated.
- `CLAUDE.md` (local-only file, not in this PR): intern guidance synced.

### Unchanged
- Kotlin package `framework.cortena.ui.*` is unchanged. Maven coordinate and source code package are independent — users keep `import framework.cortena.ui.components.Button` regardless of where the artifact is published.
- SPDX headers and "The CortenaOS Project" copyright lines are intentionally kept; CortenaOS refers to the broader ROM project, of which CortenaUI is the design system.

## Verification

- `./gradlew clean publishToMavenLocal` succeeds. POM under `~/.m2/repository/io/github/cortenaui/ui-android/0.1.0-alpha/ui-android-0.1.0-alpha.pom` declares correct `<groupId>io.github.cortenaui</groupId>` and transitive dependencies on `ui-foundation-android`, `ui-shape-android`, `ui-motion-android`.
- `python -m zensical build --clean` reports `No issues found`.

## Migration notes for the maintainer

The old `io.github.cortenaos:*` artifacts at version `0.1.0-alpha` remain on Maven Central permanently — Maven Central artifacts are immutable. We're publishing fresh artifacts under the new namespace. End users of the old namespace will need to update their `build.gradle.kts` to point at the new coordinate (covered in `docs/INSTALLATION.md`). Once `0.1.0-alpha` is verified live under the new namespace, the old GitHub repository can be archived or deleted.
