### PR TITLE
docs: overhaul installation and getting started guides

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -4,64 +4,128 @@
 
 ## Project Structure
 
-This library is divided into two main layers to ensure platform independence and a strict design language:
+CortenaUI ships as four publishable modules. Each one is independently consumable from Maven Central, and `ui` transitively pulls the other three.
 
-1. **`:foundation`**: A pure Kotlin layer with no dependencies on any UI framework. It contains raw design tokens like colors (stored as `Long` ARGB), typography sizes (`Float`), spacing (`Float`), and shape corner radii (`Float`).
-2. **`:compose`**: A Jetpack Compose implementation layer that translates tokens from `:foundation` to standard Compose UI objects (like `Color`, `.sp`, `.dp`). There are **no** dependencies on Material / Material3 here, as Cortena builds its own custom design system entirely from scratch.
+1. **`ui-foundation`** — pure Kotlin design tokens and framework-agnostic shape geometry. Zero external dependencies. Holds raw colors (`Long` ARGB), sizes (`Float`), typography (`Float` sp), motion durations (`Long` ms), and easing curves. Consumable from Compose, Android View system, and AOSP / Android.bp builds without modification.
+2. **`ui-shape`** — Compose-aware shape system. Bridges the squircle math from `ui-foundation` to the Compose `Shape` API. Provides `CapsuleShape`, `RoundedShape`, `UnevenShape`, and the `ComponentShape` hierarchy.
+3. **`ui-motion`** — spring presets, duration tiers, and easing curves used across CortenaUI. Components read motion specs through `LocalMotion` rather than constructing `spring(...)` or `tween(...)` calls inline.
+4. **`ui`** — Compose component layer (`Button`, `Slider`, `Toggle`, `Text`, `Icon`, `ScrollView`, `Theme`, etc.). Transitively pulls the three modules above.
+
+There are **no** dependencies on Material / Material3. Cortena builds its own design language entirely from scratch.
 
 ## Prerequisites
 
-Add the `:compose` module dependency (which internally includes `:foundation`) to the `build.gradle.kts` in your application module:
+CortenaUI is published to **Maven Central** under `io.github.cortenaui`. Maven Central is enabled by default in modern Gradle setups; if you have customised your repositories, make sure it is declared:
 
 ```kotlin
-implementation(project(":compose"))
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
 ```
+
+Add the dependency to your application module's `build.gradle.kts`. The recommended pattern uses a Gradle version catalog so the version stays in one place:
+
+```toml
+# gradle/libs.versions.toml
+[versions]
+cortenaui = "0.1.0-alpha"
+
+[libraries]
+cortena-ui = { module = "io.github.cortenaui:ui", version.ref = "cortenaui" }
+```
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    implementation(libs.cortena.ui)
+}
+```
+
+If you don't use a version catalog, the inline form works too:
+
+```kotlin
+dependencies {
+    implementation("io.github.cortenaui:ui:0.1.0-alpha")
+}
+```
+
+### Build configuration
+
+CortenaUI's `ui` module targets modern Android. Your application module must compile against API 37 or newer:
+
+```kotlin
+android {
+    compileSdk = 37  // minimum, newer is fine
+    defaultConfig {
+        minSdk = 35  // required for the ui module
+    }
+}
+```
+
+For details on what each module requires and on cherry-picking individual modules, see [INSTALLATION](INSTALLATION.md).
+
+### A note on Material
+
+CortenaUI is a complete design system. Mixing it with Material 3 in the same screen produces inconsistent visuals — Material's components have their own typography, motion, and shape language that fights with Cortena's. **Use one or the other within a screen**. The catalog uses Material icons under `androidx.compose.material.icons` purely as a vector source for `Icon`; that is the only Material touchpoint we recommend.
 
 ## How to Use
 
 1. Start your user interface at the root of your `Activity` using **`ContentView`**.
-2. **`ContentView`** will automatically:
-   - Call `enableEdgeToEdge()`.
-   - Redraw the status bar color as needed.
-   - Enable status bar icons contrast detection.
-   - Wrap its content using **`Theme`**.
-3. Compose your UI using `Body`, `SafeArea`, `AppBar`, `Text`, and so on.
+2. **`ContentView`** automatically:
+   - Calls `enableEdgeToEdge()` for transparent system bars.
+   - Wraps content in **`Theme`** with the requested `themeMode`, palette, typography, fontFamily, sizeToken, and motion.
+   - Manages status bar icon contrast (`StatusBarIconMode`).
+   - Renders an optional status bar color overlay and an `appBar` slot above the main content.
+3. Inside `ContentView`, compose your screen with **`Body`** (edge-to-edge background container), **`ScrollView`** (when content can overflow), **`SafeArea`** (system insets padding), and the rest of the components.
 
-### Simple Implementation Example (Android)
+### Minimal Android example
+
+The shape below mirrors the catalog's own `MainActivity`. It is the smallest possible app that uses every layout primitive correctly:
 
 ```kotlin
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import framework.cortena.ui.components.Button
 import framework.cortena.ui.components.Text
-import framework.cortena.ui.layout.AppBar
+import framework.cortena.ui.components.TextRole
 import framework.cortena.ui.layout.Body
 import framework.cortena.ui.layout.ContentView
 import framework.cortena.ui.layout.SafeArea
-import framework.cortena.ui.theme.StatusBarIconMode
-import framework.cortena.ui.theme.ThemeMode
+import framework.cortena.ui.layout.ScrollView
+import framework.cortena.ui.theme.LocalColors
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        // The root of the application, automatically handles Edge-to-Edge and Theme Injector
-        ContentView(
-            appBar = {
-                AppBar(modifier = Modifier.background(Color.DarkGray)) {}
-            },
-            statusBarColor = Color.DarkGray,
-            statusBarIconMode = StatusBarIconMode.Auto, // Will automatically calculate light/dark icons
-            themeMode = ThemeMode.Auto
-        ) {
-            Body(modifier = Modifier.background(Color.Black)) {
-                SafeArea {
-                    Text(
-                        text = "Welcome to Cortena UI!",
-                        color = Color.White
-                    )
+        ContentView {
+            Body {
+                ScrollView {
+                    SafeArea {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                        ) {
+                            val colors = LocalColors.current
+                            Text(
+                                "Hello CortenaUI",
+                                color = Color(colors.primary),
+                                role = TextRole.TitleMedium,
+                            )
+                            Button(onClick = { /* ... */ }) {
+                                Text("Get started")
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -69,9 +133,29 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
+`ContentView` accepts `themeMode` as a state-producer lambda (`() -> ThemeMode`) so a parent can flip the theme without recomposing the entire tree.
+
+### Adding a custom font
+
+Drop a font file into `app/src/main/res/font/` and pass it via `ContentView`:
+
+```kotlin
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+
+ContentView(
+    themeMode = { themeMode.value },
+    fontFamily = FontFamily(Font(R.font.your_font)),
+) {
+    // ...
+}
+```
+
+Every `Text` component in the tree picks up the new family automatically.
+
 ## References
 
-Visit the layout guides individually in the `docs/layout/` directory:
+Layout primitives — `docs/layout/`:
 
 - [ContentView](layout/ContentView.md)
 - [Theme](layout/Theme.md)
@@ -79,16 +163,19 @@ Visit the layout guides individually in the `docs/layout/` directory:
 - [SafeArea](layout/SafeArea.md)
 - [ScrollView](layout/ScrollView.md)
 
-Visit the component guides individually in the `docs/components/` directory:
+Components — `docs/components/`:
 
 - [AppBar](components/AppBar.md)
 - [Button](components/Button.md)
+- [Icon](components/Icon.md)
 - [Separator](components/Separator.md)
 - [Slider](components/Slider.md)
 - [Text](components/Text.md)
 - [Toggle](components/Toggle.md)
 
-Visit the extra guides individually in the `docs/extra/` directory:
+Design language — `docs/extra/`:
 
 - [Motion](extra/Motion.md)
 - [Shape](extra/Shape.md)
+
+For installation details, modular adoption, and version policy, see [INSTALLATION](INSTALLATION.md).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,7 +6,7 @@ CortenaUI is published to **Maven Central** under the `io.github.cortenaui` grou
 
 ## Repository
 
-Maven Central is enabled by default in modern Gradle setups. If you have customised your repositories, add it back:
+Maven Central is enabled by default in modern Gradle setups. If you have customised your repositories, declare it explicitly:
 
 ```kotlin
 // settings.gradle.kts
@@ -22,28 +22,58 @@ dependencyResolutionManagement {
 
 The most common case. The `ui` artifact transitively pulls `ui-foundation`, `ui-shape`, and `ui-motion`, so you get the full component library with one dependency.
 
+The recommended pattern uses a Gradle version catalog so the version stays in one place across multi-module apps:
+
+```toml
+# gradle/libs.versions.toml
+[versions]
+cortenaui = "0.1.0-alpha"
+
+[libraries]
+cortena-ui = { module = "io.github.cortenaui:ui", version.ref = "cortenaui" }
+```
+
 ```kotlin
 // app/build.gradle.kts
+dependencies {
+    implementation(libs.cortena.ui)
+}
+```
+
+If you don't use a version catalog, the inline form works just as well:
+
+```kotlin
 dependencies {
     implementation("io.github.cortenaui:ui:0.1.0-alpha")
 }
 ```
 
-After this single line you can use the entire framework:
+After this single line you can use the entire framework. The minimal Android entry point looks like this — note the `ContentView → Body → ScrollView → SafeArea` layering, which is the canonical pattern (see [GETTING-STARTED](GETTING-STARTED.md) for a fuller walkthrough):
 
 ```kotlin
+import android.os.Bundle
+import androidx.activity.ComponentActivity
 import framework.cortena.ui.components.Button
 import framework.cortena.ui.components.Text
-import framework.cortena.ui.components.Toggle
+import framework.cortena.ui.layout.Body
+import framework.cortena.ui.layout.ContentView
+import framework.cortena.ui.layout.SafeArea
 import framework.cortena.ui.layout.ScrollView
-import framework.cortena.ui.theme.Theme
-import framework.cortena.ui.shape.CapsuleShape
-import framework.cortena.ui.motion.LocalMotion
 
-@Composable
-fun App() {
-    Theme {
-        Button(onClick = { }) { Text("Hello CortenaUI") }
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        ContentView {
+            Body {
+                ScrollView {
+                    SafeArea {
+                        Button(onClick = { /* ... */ }) {
+                            Text("Hello CortenaUI")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 ```
@@ -138,29 +168,65 @@ Drop them into your project's `libs/` folder if you need an offline-friendly ins
 
 ## Requirements
 
+- **Compile SDK**: 37 (Android 17) or newer. Required for the `ui` module.
 - **Min SDK**: 35 for `ui`, 21 for `ui-foundation`, `ui-shape`, and `ui-motion`.
-- **Compile SDK**: 37+.
 - **Kotlin**: 2.3+.
 - **Compose Multiplatform**: 1.10.3+.
 
-## Verifying the install
-
-After syncing, render the catalog snippet:
+The `ui` module's `compileSdk = 37` is the **minimum**, not an exact pin — newer versions are supported. If your application module currently builds against a lower SDK, bump `compileSdk` in `app/build.gradle.kts`:
 
 ```kotlin
+android {
+    compileSdk = 37  // minimum, newer is fine
+    defaultConfig {
+        minSdk = 35  // required for the ui module
+    }
+}
+```
+
+## Mixing with Material 3
+
+CortenaUI is a complete design system. Mixing it with Material 3 in the same screen produces visual inconsistencies — Material's components have their own typography, motion, and shape language that competes with Cortena's. **Pick one or the other per screen**.
+
+The catalog imports vector assets from `androidx.compose.material.icons` (e.g. `Icons.Default.Add`) and feeds them into Cortena's own `Icon` composable. That is the one safe touchpoint: Material as a vector source, never as a renderer.
+
+```kotlin
+// Recommended
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import framework.cortena.ui.components.Icon
+
+Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
+```
+
+```kotlin
+// Avoid
+import androidx.compose.material3.Icon  // Material's renderer
+import androidx.compose.material3.Button // Material's component
+```
+
+## Verifying the install
+
+After syncing, the smallest sanity-check screen looks like this:
+
+```kotlin
+import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import framework.cortena.ui.components.Button
 import framework.cortena.ui.components.Text
-import framework.cortena.ui.theme.Theme
+import framework.cortena.ui.layout.Body
+import framework.cortena.ui.layout.ContentView
+import framework.cortena.ui.layout.SafeArea
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent {
-            Theme {
-                Button(onClick = { /* TODO */ }) {
-                    Text("CortenaUI is installed")
+        ContentView {
+            Body {
+                SafeArea {
+                    Button(onClick = { }) {
+                        Text("CortenaUI is installed")
+                    }
                 }
             }
         }
@@ -168,4 +234,4 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
-If the button renders with the capsule shape, spring press response, and onPrimary color, you are set.
+If the button renders with the capsule shape, spring press response, and theme-aware colors — and the system bars look correctly handled (status bar icons readable, edge-to-edge layout) — the install is sound.


### PR DESCRIPTION
Add modern Gradle version catalog dependency patterns, clarify the library's four-module structure, update Android activity code examples, add guidance on avoiding Material 3 component conflicts, expand build configuration and requirements details, add font customization instructions, and cross-reference between the two documentation files properly.