### PR TITLE
Migrate to Phosphor Icons and update Icon component functionality

### DIFF
--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -40,5 +40,5 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui)
-    implementation(libs.cortena.icons.phosphor)
+    implementation(libs.cortena.icons)
 }

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -37,9 +37,8 @@ dependencies {
     implementation(project(":compose"))
 
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.compose.foundation)
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui)
+    implementation(libs.cortena.icons.phosphor)
 }

--- a/catalog/src/main/kotlin/app/cortena/ui/catalog/MainActivity.kt
+++ b/catalog/src/main/kotlin/app/cortena/ui/catalog/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import app.cortena.ui.catalog.demo.ButtonDemo
 import app.cortena.ui.catalog.demo.ColorDemo
 import app.cortena.ui.catalog.demo.GridViewDemo
+import app.cortena.ui.catalog.demo.IconDemo
 import app.cortena.ui.catalog.demo.LazyGridViewDemo
 import app.cortena.ui.catalog.demo.LazyScrollViewDemo
 import app.cortena.ui.catalog.demo.ScrollViewDemo
@@ -86,6 +87,8 @@ class MainActivity : ComponentActivity() {
                             TypographyDemo()
                             Separator(modifier = Modifier.padding(vertical = 12.dp))
                             ButtonDemo()
+                            Separator(modifier = Modifier.padding(vertical = 12.dp))
+                            IconDemo()
                             Separator(modifier = Modifier.padding(vertical = 12.dp))
                             SliderDemo()
                             Separator(modifier = Modifier.padding(vertical = 12.dp))

--- a/catalog/src/main/kotlin/app/cortena/ui/catalog/demo/Button.kt
+++ b/catalog/src/main/kotlin/app/cortena/ui/catalog/demo/Button.kt
@@ -7,10 +7,6 @@ package app.cortena.ui.catalog.demo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,6 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import framework.cortena.icons.PhosphorIcon
+import framework.cortena.icons.PhosphorIcons
 import framework.cortena.ui.color.ColorToken
 import framework.cortena.ui.components.Button
 import framework.cortena.ui.components.ButtonStyle
@@ -79,7 +77,7 @@ fun ButtonDemo() {
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         Button(enabled = enable, background = ColorToken.Blue500.value()) {
             Icon(
-                imageVector = Icons.Default.Favorite,
+                renderer = PhosphorIcon(PhosphorIcons.Fill.Heart),
                 contentDescription = "Favorite icon",
                 tint = ColorToken.Blue50.value(),
             )
@@ -88,14 +86,14 @@ fun ButtonDemo() {
         Button(enabled = enable, background = ColorToken.Green600.value()) { Text("Green") }
         Button(enabled = enable, iconOnly = true, background = ColorToken.Orange500.value()) {
             Icon(
-                imageVector = Icons.Default.Add,
+                renderer = PhosphorIcon(PhosphorIcons.Regular.Plus),
                 contentDescription = "Add icon",
                 tint = Color.White,
             )
         }
         Button(enabled = enable, iconOnly = true, background = ColorToken.Pink500.value()) {
             Icon(
-                imageVector = Icons.Default.Edit,
+                renderer = PhosphorIcon(PhosphorIcons.Regular.PencilSimple),
                 contentDescription = "Edit icon",
                 tint = Color.White,
             )
@@ -118,21 +116,21 @@ fun ButtonDemo() {
     ) {
         Button(enabled = enable, iconOnly = true, size = SizeToken.Small) {
             Icon(
-                imageVector = Icons.Default.Add,
+                renderer = PhosphorIcon(PhosphorIcons.Regular.Plus),
                 contentDescription = "Add icon",
                 tint = Color.White,
             )
         }
         Button(enabled = enable, iconOnly = true, size = SizeToken.Medium) {
             Icon(
-                imageVector = Icons.Default.Add,
+                renderer = PhosphorIcon(PhosphorIcons.Regular.Plus),
                 contentDescription = "Add icon",
                 tint = Color.White,
             )
         }
         Button(enabled = enable, iconOnly = true, size = SizeToken.Large) {
             Icon(
-                imageVector = Icons.Default.Add,
+                renderer = PhosphorIcon(PhosphorIcons.Regular.Plus),
                 contentDescription = "Add icon",
                 tint = Color.White,
             )

--- a/catalog/src/main/kotlin/app/cortena/ui/catalog/demo/Icon.kt
+++ b/catalog/src/main/kotlin/app/cortena/ui/catalog/demo/Icon.kt
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (C) 2026-present The CortenaOS Project
+ */
+package app.cortena.ui.catalog.demo
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import framework.cortena.icons.PhosphorIcon
+import framework.cortena.icons.PhosphorIcons
+import framework.cortena.ui.color.ColorToken
+import framework.cortena.ui.components.Icon
+import framework.cortena.ui.components.Text
+import framework.cortena.ui.components.TextRole
+import framework.cortena.ui.components.Toggle
+import framework.cortena.ui.theme.LocalColors
+import framework.cortena.ui.theme.value
+
+@Composable
+fun IconDemo() {
+    val colors = LocalColors.current
+    Text("Icon", color = Color(colors.primary), role = TextRole.TitleMedium)
+
+    var enabled by remember { mutableStateOf(true) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Enable Icon")
+        Toggle(checked = enabled, onCheckedChange = { enabled = it })
+    }
+
+    Text("Phosphor Icons")
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Regular.House),
+            contentDescription = "House",
+            enabled = enabled
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Regular.Heart),
+            contentDescription = "Heart",
+            enabled = enabled
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Regular.Gear),
+            contentDescription = "Gear",
+            enabled = enabled
+        )
+    }
+
+    Text("Phosphor Weights")
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Thin.Star),
+            contentDescription = "Thin",
+            enabled = enabled
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Light.Star),
+            contentDescription = "Light",
+            enabled = enabled
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Regular.Star),
+            contentDescription = "Regular",
+            enabled = enabled
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Bold.Star),
+            contentDescription = "Bold",
+            enabled = enabled
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Fill.Star),
+            contentDescription = "Fill",
+            enabled = enabled
+        )
+    }
+
+    Text("Phosphor with Custom Tint")
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Fill.Heart),
+            contentDescription = "Red Heart",
+            tint = ColorToken.Red500.value(),
+            enabled = enabled,
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Fill.Star),
+            contentDescription = "Yellow Star",
+            tint = ColorToken.Yellow500.value(),
+            enabled = enabled,
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Fill.Lightning),
+            contentDescription = "Orange Lightning",
+            tint = ColorToken.Orange500.value(),
+            enabled = enabled,
+        )
+    }
+
+    Text("Phosphor with Custom Size")
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Bold.Rocket),
+            contentDescription = "16dp",
+            size = 16.dp,
+            enabled = enabled,
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Bold.Rocket),
+            contentDescription = "24dp",
+            size = 24.dp,
+            enabled = enabled,
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Bold.Rocket),
+            contentDescription = "32dp",
+            size = 32.dp,
+            enabled = enabled,
+        )
+        Icon(
+            renderer = PhosphorIcon(PhosphorIcons.Bold.Rocket),
+            contentDescription = "48dp",
+            size = 48.dp,
+            enabled = enabled,
+        )
+    }
+}

--- a/compose/src/commonMain/kotlin/framework/cortena/ui/components/Icon.kt
+++ b/compose/src/commonMain/kotlin/framework/cortena/ui/components/Icon.kt
@@ -5,6 +5,7 @@
 package framework.cortena.ui.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size as foundationSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -16,20 +17,17 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import framework.cortena.ui.theme.LocalColors
 import framework.cortena.ui.theme.LocalContentColor
 import framework.cortena.ui.theme.LocalIconSize
-import androidx.compose.foundation.layout.size as foundationSize
-import framework.cortena.ui.theme.LocalColors
 
 /**
- * CortenaUI — Icon
+ * CortenaUI � Icon
  *
- * Renders an [ImageVector] as a tinted icon with a default size resolved from
- * [LocalIconSize]. When this composable is used inside a sized component scope (for example a
- * [Button] content slot), the local icon size automatically scales with the parent's
- * [framework.cortena.ui.size.SizeToken]. Outside such a scope it falls back to a sensible
- * default (24.dp).
+ * Renders an [ImageVector] as a tinted icon with a default size resolved from [LocalIconSize]. When
+ * this composable is used inside a sized component scope (for example a [Button] content slot), the
+ * local icon size automatically scales with the parent's [framework.cortena.ui.size.SizeToken].
+ * Outside such a scope it falls back to a sensible default (24.dp).
  *
  * Tint resolution mirrors [Text]: [LocalContentColor] when set, else `LocalColors.onBackground`.
  *
@@ -64,4 +62,54 @@ fun Icon(
         contentScale = ContentScale.Fit,
         colorFilter = ColorFilter.tint(resolvedTint),
     )
+}
+
+/**
+ * Typealias for an icon renderer: a composable lambda that draws a single icon glyph.
+ *
+ * External icon packs (e.g. `cortenaui-phosphor-icons`) produce an [IconRenderer] via their factory
+ * function so that CortenaUI can own tint, size, accessibility, and enabled-state behavior while
+ * the pack owns the actual drawing.
+ */
+typealias IconRenderer =
+    @Composable
+    (
+        modifier: Modifier, tint: Color, size: Dp, enabled: Boolean, contentDescription: String?
+    ) -> Unit
+
+/**
+ * CortenaUI � Icon (renderer overload)
+ *
+ * Renders an icon using an [IconRenderer] lambda instead of an [ImageVector]. This overload lets
+ * external icon packs (like Phosphor Icons) plug into CortenaUI's Icon component while CortenaUI
+ * still owns tint resolution, size resolution, and enabled-state logic.
+ *
+ * Usage with the phosphor-icons library:
+ * ```
+ * Icon(
+ *     renderer = PhosphorIcon(PhosphorIcons.Bold.Alarm),
+ *     contentDescription = "Alarm",
+ * )
+ * ```
+ */
+@Composable
+fun Icon(
+    renderer: IconRenderer,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified,
+    size: Dp = Dp.Unspecified,
+    enabled: Boolean = true,
+) {
+    val colors = LocalColors.current
+    val localContentColor = LocalContentColor.current
+    val resolvedSize = if (size != Dp.Unspecified) size else LocalIconSize.current
+    val resolvedTint =
+        when {
+            tint.isSpecified -> tint
+            localContentColor != null && localContentColor.isSpecified -> localContentColor
+            else -> Color(colors.onBackground)
+        }
+
+    renderer(modifier, resolvedTint, resolvedSize, enabled, contentDescription)
 }

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -70,7 +70,23 @@ For details on what each module requires and on cherry-picking individual module
 
 ### A note on Material
 
-CortenaUI is a complete design system. Mixing it with Material 3 in the same screen produces inconsistent visuals — Material's components have their own typography, motion, and shape language that fights with Cortena's. **Use one or the other within a screen**. The catalog uses Material icons under `androidx.compose.material.icons` purely as a vector source for `Icon`; that is the only Material touchpoint we recommend.
+CortenaUI is a complete design system. Mixing it with Material 3 in the same screen produces inconsistent visuals — Material's components have their own typography, motion, and shape language that fights with Cortena's. **Use one or the other within a screen**. There are zero Material dependencies in CortenaUI.
+
+### Icons
+
+We recommend using the official `cortenaui-phosphor-icons` library which integrates natively with CortenaUI's `Icon` component.
+
+```toml
+# gradle/libs.versions.toml
+cortena-icons-phosphor = { module = "io.github.cortenaui:phosphor_icons", version.ref = "cortenaui" }
+```
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    implementation(libs.cortena.icons.phosphor)
+}
+```
 
 ## How to Use
 

--- a/docs/components/Icon.md
+++ b/docs/components/Icon.md
@@ -1,17 +1,37 @@
 # Icon
 
-`Icon` renders a vector graphic with a tinted color. Built on top of `compose.foundation.Image` so it stays inside the Material-free constraint of `:compose`.
+`Icon` renders a graphic icon with a tinted color. It provides two overloads: one for `IconRenderer` lambdas (used by font-backed icon packs like Phosphor Icons) and one for `ImageVector` assets. Built on top of `compose.foundation.Image` and `BasicText` so it stays inside the Material-free constraint of `:compose`.
 
 ## Concept
 
-An icon in CortenaUI is rendered from an `ImageVector` (typically sourced from `androidx.compose.material.icons` in the consumer app, or any vector asset). It is tinted using the resolved content color and sized via `LocalIconSize`, which lets sized parents like `Button` automatically scale icons with their tier.
+An icon in CortenaUI relies on CortenaUI to resolve its size and tint, while delegating the actual drawing to a renderer or vector painter.
 
 1. **Default Size**: Resolves from `LocalIconSize.current`. Inside a `Button`, this matches the button's `SizeToken.iconSize`. Outside any sized scope it defaults to `24.dp`.
 2. **Tint Resolution**: Mirrors `Text`. If `tint` is unspecified, falls back to `LocalContentColor.current` and finally to `Palette.onBackground`.
 3. **Disabled State**: Renders at `alpha = 0.38f`.
-4. **Material-Free**: Does not depend on `androidx.compose.material` or `material3`. Consumers may still source vector assets from Material Icons because `ImageVector` itself lives in `compose.ui.graphics.vector`.
+4. **Renderer vs Vector**: You can use CortenaUI's official `cortenaui-phosphor-icons` library which provides an `IconRenderer`, or fallback to custom `ImageVector` assets.
 
 ## API Reference
+
+### Renderer Overload (Recommended)
+
+Used for external icon packs like Phosphor Icons that implement the `IconRenderer` contract.
+
+```kotlin
+@Composable
+fun Icon(
+    renderer: IconRenderer,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified,
+    size: Dp = Dp.Unspecified,
+    enabled: Boolean = true,
+)
+```
+
+### ImageVector Overload
+
+Used for custom vector assets or legacy `androidx.compose.material.icons` graphics.
 
 ```kotlin
 @Composable
@@ -27,43 +47,50 @@ fun Icon(
 
 ### Parameters
 
-| Name                 | Data Type     | Description                                                                                                                          |
-| -------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `imageVector`        | `ImageVector` | The vector graphic to render. Typically from `androidx.compose.material.icons.Icons.Default.*` or a custom asset.                    |
-| `contentDescription` | `String?`     | Accessibility description. Pass `null` only for purely decorative icons that have an adjacent text label.                            |
-| `modifier`           | `Modifier`    | Standard Compose modifier. Note: size is applied internally based on `size` / `LocalIconSize`; further size modifiers will compound. |
-| `tint`               | `Color`       | Tint applied to the vector. Defaults to `Color.Unspecified`, which falls back to `LocalContentColor` or `Palette.onBackground`.      |
-| `size`               | `Dp`          | Override the resolved icon size. `Dp.Unspecified` uses `LocalIconSize.current`.                                                      |
-| `enabled`            | `Boolean`     | When `false` renders at `alpha = 0.38f`. Default: `true`.                                                                            |
+| Name                 | Data Type      | Description                                                                                                                          |
+| -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `renderer`           | `IconRenderer` | A composable lambda that draws the icon glyph. Typically provided by `PhosphorIcon(...)`.                                            |
+| `imageVector`        | `ImageVector`  | The vector graphic to render. Typically from a custom asset.                                                                         |
+| `contentDescription` | `String?`      | Accessibility description. Pass `null` only for purely decorative icons that have an adjacent text label.                            |
+| `modifier`           | `Modifier`     | Standard Compose modifier. Note: size is applied internally based on `size` / `LocalIconSize`; further size modifiers will compound. |
+| `tint`               | `Color`        | Tint applied to the graphic. Defaults to `Color.Unspecified`, which falls back to `LocalContentColor` or `Palette.onBackground`.     |
+| `size`               | `Dp`           | Override the resolved icon size. `Dp.Unspecified` uses `LocalIconSize.current`.                                                      |
+| `enabled`            | `Boolean`      | When `false` renders at `alpha = 0.38f`. Default: `true`.                                                                            |
 
 ## Examples
 
-#### Inside a Button — automatic sizing
+### Inside a Button — automatic sizing
 
 ```kotlin
 Button(onClick = { }, size = SizeToken.Large) {
-    Icon(imageVector = Icons.Default.Favorite, contentDescription = "Favorite")
+    Icon(
+        renderer = PhosphorIcon(PhosphorIcons.Fill.Heart),
+        contentDescription = "Favorite",
+    )
     Text("Like")
 }
 // The icon renders at the Large tier's iconSize (≈25.4 dp); the Text renders at BodyLarge.
 ```
 
-#### Standalone with a custom tint
+### Standalone with a custom tint
 
 ```kotlin
 Icon(
-    imageVector = Icons.Default.Add,
+    renderer = PhosphorIcon(PhosphorIcons.Regular.Plus),
     contentDescription = "Add",
     tint = Color(LocalColors.current.primary),
     size = 28.dp,
 )
 ```
 
-#### Decorative icon next to a label
+### Decorative icon next to a label
 
 ```kotlin
 Row(verticalAlignment = Alignment.CenterVertically) {
-    Icon(imageVector = Icons.Default.Info, contentDescription = null)
+    Icon(
+        renderer = PhosphorIcon(PhosphorIcons.Regular.Info),
+        contentDescription = null,
+    )
     Text(" 12 unread", role = TextRole.BodySmall)
 }
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,20 +2,18 @@
 activityCompose = "1.13.0"
 agp = "9.2.1"
 compose = "1.11.0"
+icons = "1.0.0"
 jetbrainsKotlinJvm = "2.3.21"
-icons = "1.7.8"
 kotlin = "2.3.21"
-material3 = "1.4.0"
 mavenPublish = "0.36.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
-androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "icons" }
 compose-animation-core = { module = "org.jetbrains.compose.animation:animation-core", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
+cortena-icons-phosphor = { module = "io.github.cortenaui:phosphor_icons", version.ref = "icons" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ compose-animation-core = { module = "org.jetbrains.compose.animation:animation-c
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
-cortena-icons-phosphor = { module = "io.github.cortenaui:phosphor_icons", version.ref = "icons" }
+cortena-icons = { module = "io.github.cortenaui:phosphor_icons", version.ref = "icons" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activityCompose = "1.13.0"
 agp = "9.2.1"
-compose = "1.11.0"
+compose = "1.11.1"
 icons = "1.0.0"
 jetbrainsKotlinJvm = "2.4.0"
 kotlin = "2.4.0"


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
*   **Impact:** Medium - Replaces Material icons with Phosphor icons across the catalog and introduces a new flexible rendering pattern for icons.
*   **Key Changes:**
    *   Introduced `IconRenderer` typealias and a new `Icon` composable overload to natively support external icon packs (e.g., Phosphor Icons) while CortenaUI manages size and tint.
    *   Removed Material 3 and Material Icons Extended dependencies entirely from the project.
    *   Migrated the component catalog (`Button` demo) to use `PhosphorIcon`.
    *   Added a dedicated `IconDemo` screen to the catalog.
    *   Updated documentation and added a comprehensive `CLAUDE.md` file outlining project philosophy and architecture.

## 2. Visual Overview (Code & Logic Map)

```mermaid
graph TD
    subgraph compose/src/commonMain/kotlin/framework/cortena/ui/components
        I[/"Icon.kt"/]
        IR["IconRenderer (Typealias)"]
        IO1["Icon(renderer: IconRenderer)"]
        IO2["Icon(imageVector: ImageVector)"]
        
        I --> IR
        I --> IO1
        I --> IO2
    end
    
    subgraph External Icon Pack
        PI["PhosphorIcon()"]
    end
    
    subgraph catalog/src/main/kotlin/app/cortena/ui/catalog/demo
        ID[/"Icon.kt (Demo)"/]
        BD[/"Button.kt (Demo)"/]
        
        ID --> PI
        BD --> PI
        PI --> IO1
    end
    
    style I fill:#f3e5f5,color:#7b1fa2
    style IR fill:#fff3e0,color:#e65100
    style IO1 fill:#bbdefb,color:#0d47a1
    style IO2 fill:#bbdefb,color:#0d47a1
    style PI fill:#c8e6c9,color:#1a5e20
```

## 3. Detailed Change Analysis

### Icon Component (`:compose` module)
*   **Component Name:** `Icon`
*   **What Changed:** Added a new `IconRenderer` typealias and an `Icon` overload that accepts a `renderer` instead of an `ImageVector`. This design allows CortenaUI to centralize tint, size resolution, and enabled-state logic while delegating the actual glyph drawing to external packs like `cortenaui-phosphor-icons` (Source: `Icon.kt`).

### Catalog Demos (`:catalog` module)
*   **Component Name:** `Catalog Demos`
*   **What Changed:** 
    *   Replaced all `Icons.Default.*` (Material icons) with `PhosphorIcon(PhosphorIcons.*)` in the existing `Button.kt` demo.
    *   Created a new `Icon.kt` demo file to showcase various Phosphor icon styles (Regular, Thin, Light, Bold, Fill) and custom tints.
    *   Updated `MainActivity.kt` to include the new `IconDemo()`.

### Dependencies & Configuration
*   **Component Name:** Build Scripts
*   **What Changed:** Purged Material dependencies to enforce CortenaUI's independent design system and integrated the Phosphor Icons dependency. Also added a `CLAUDE.md` context file for AI assistants to understand the project architecture and philosophy.

| Package | Action | Reason |
|---------|--------|--------|
| `androidx.compose.material3:material3` | Removed | Purging Material design elements to enforce CortenaUI's custom design system. |
| `androidx.compose.material:material-icons-extended` | Removed | Replaced by Phosphor icons. |
| `io.github.cortenaui:phosphor_icons` | Added | New official icon pack integration. |

### Documentation (`docs/`)
*   **Component Name:** Markdown Docs
*   **What Changed:** 
    *   Updated `GETTING-STARTED.md` to recommend `cortenaui-phosphor-icons` and clarify that CortenaUI has zero Material dependencies.
    *   Updated `Icon.md` to document the new `IconRenderer` overload and provide clear examples of how to use Phosphor icons inside and outside of sized components.

## 4. Impact & Risk Assessment
*   **Breaking Changes:** None for the core library's API, but the `:catalog` module no longer has Material dependencies. The `Icon` component is fully backward compatible as the `ImageVector` overload is preserved.
*   **Testing Suggestions:** 
    *   Verify that `PhosphorIcon` renders correctly in all states (enabled/disabled).
    *   Confirm that icons scale appropriately when placed inside sized components like `Button` (`SizeToken` resolution).
    *   Check that the catalog app builds successfully and runs without the Material dependencies.