### PR TITLE
Release version 0.3.0-alpha

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,5 +11,5 @@ plugins {
 
 allprojects {
     group = "io.github.cortenaui"
-    version = "0.2.0-alpha"
+    version = "0.3.0-alpha"
 }

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = 35
         targetSdk = 37
         versionCode = 2
-        versionName = "0.2.0-alpha"
+        versionName = "0.3.0-alpha"
     }
 
     buildTypes {

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -32,7 +32,7 @@ Add the dependency to your application module's `build.gradle.kts`. The recommen
 ```toml
 # gradle/libs.versions.toml
 [versions]
-cortenaui = "0.2.0-alpha"
+cortenaui = "0.3.0-alpha"
 
 [libraries]
 cortena-ui = { module = "io.github.cortenaui:ui", version.ref = "cortenaui" }
@@ -49,7 +49,7 @@ If you don't use a version catalog, the inline form works too:
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaui:ui:0.2.0-alpha")
+    implementation("io.github.cortenaui:ui:0.3.0-alpha")
 }
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -27,7 +27,7 @@ The recommended pattern uses a Gradle version catalog so the version stays in on
 ```toml
 # gradle/libs.versions.toml
 [versions]
-cortenaui = "0.2.0-alpha"
+cortenaui = "0.3.0-alpha"
 
 [libraries]
 cortena-ui = { module = "io.github.cortenaui:ui", version.ref = "cortenaui" }
@@ -44,7 +44,7 @@ If you don't use a version catalog, the inline form works just as well:
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaui:ui:0.2.0-alpha")
+    implementation("io.github.cortenaui:ui:0.3.0-alpha")
 }
 ```
 
@@ -88,7 +88,7 @@ Pure Kotlin, zero dependencies. Use this if you want CortenaUI's color / size / 
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaui:ui-foundation:0.2.0-alpha")
+    implementation("io.github.cortenaui:ui-foundation:0.3.0-alpha")
 }
 ```
 
@@ -105,7 +105,7 @@ Compose `Shape` adapter for CortenaUI's squircle math. Useful for adopters who w
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaui:ui-shape:0.2.0-alpha")
+    implementation("io.github.cortenaui:ui-shape:0.3.0-alpha")
 }
 ```
 
@@ -121,7 +121,7 @@ Spring presets, duration tiers, and easing curves used across CortenaUI. Adopt t
 
 ```kotlin
 dependencies {
-    implementation("io.github.cortenaui:ui-motion:0.2.0-alpha")
+    implementation("io.github.cortenaui:ui-motion:0.3.0-alpha")
 }
 ```
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -11,7 +11,7 @@ CortenaUI publishes four artifacts to **Maven Central** under the `io.github.cor
 
 The `ui` artifact is the meta-artifact users normally depend on — it transitively pulls every other module. The `ui-*` siblings let consumers cherry-pick.
 
-Publishing is automated through the `Publish` GitHub Actions workflow. Pushing a tag of the form `v<version>` (for example `v0.2.0-alpha`) triggers a build, signs every artifact, uploads them to Maven Central, and attaches the per-module AARs to a GitHub Release.
+Publishing is automated through the `Publish` GitHub Actions workflow. Pushing a tag of the form `v<version>` (for example `v0.3.0-alpha`) triggers a build, signs every artifact, uploads them to Maven Central, and attaches the per-module AARs to a GitHub Release.
 
 ## One-time setup
 
@@ -121,7 +121,7 @@ dependencyResolutionManagement {
 ```kotlin
 // app/build.gradle.kts
 dependencies {
-    implementation("io.github.cortenaui:ui:0.2.0-alpha")
+    implementation("io.github.cortenaui:ui:0.3.0-alpha")
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cortenaui"
-version = "0.2.0-alpha"
+version = "0.3.0-alpha"
 description = "Modular UI components for Jetpack Compose"
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)

- **Impact:** Low
- **Key Changes:**
  - Bumped project version from `0.2.0-alpha` to `0.3.0-alpha` across Gradle build files, Python configuration, and all related documentation.

## 2. Visual Overview (Code & Logic Map)

```mermaid
graph TD
    subgraph Version Bump
        A["build.gradle.kts"] -->|"Update Version"| V["0.3.0-alpha"]
        B["catalog/build.gradle.kts"] -->|"Update Version"| V
        C["pyproject.toml"] -->|"Update Version"| V
        D["Docs (*.md)"] -->|"Update Version"| V
    end

    style A fill:#e3f2fd,color:#0d47a1
    style B fill:#e3f2fd,color:#0d47a1
    style C fill:#e3f2fd,color:#0d47a1
    style D fill:#e3f2fd,color:#0d47a1
    style V fill:#c8e6c9,color:#1a5e20
```

## 3. Detailed Change Analysis

### Version Upgrades

- **Component Name:** Configuration & Documentation
- **What Changed:** The project version has been updated to reflect the new `0.3.0-alpha` release. This change spans across the root and catalog Gradle files, Python project configuration, and markdown documentation examples.

| File                       | Old Value     | New Value     | Description            |
| -------------------------- | ------------- | ------------- | ---------------------- |
| `build.gradle.kts`         | `0.2.0-alpha` | `0.3.0-alpha` | Root project version   |
| `catalog/build.gradle.kts` | `0.2.0-alpha` | `0.3.0-alpha` | Catalog app version    |
| `pyproject.toml`           | `0.2.0-alpha` | `0.3.0-alpha` | Python package version |
| `docs/GETTING-STARTED.md`  | `0.2.0-alpha` | `0.3.0-alpha` | Documentation examples |
| `docs/INSTALLATION.md`     | `0.2.0-alpha` | `0.3.0-alpha` | Documentation examples |
| `docs/PUBLISHING.md`       | `0.2.0-alpha` | `0.3.0-alpha` | Documentation examples |

## 4. Impact & Risk Assessment

- **Breaking Changes:** None. This pull request consists only of version string updates and documentation additions.
- **Testing Suggestions:**
  - Verify that the Gradle build syncs properly with the new `0.3.0-alpha` version.
  - Confirm that the `pyproject.toml` version bump does not cause any packaging conflicts if automated releases are triggered.
