### PR TITLE
feat(publish): add catalog APK to GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,18 +63,22 @@ jobs:
       - name: Assemble release AARs for GitHub Release
         run: ./gradlew :foundation:assemble :shape:assemble :motion:assemble :compose:assemble --stacktrace
 
-      - name: Collect AARs
+      - name: Assemble catalog release APK
+        run: ./gradlew :catalog:assembleRelease --stacktrace
+
+      - name: Collect release artifacts
         run: |
           mkdir -p release-artifacts
           cp foundation/build/outputs/aar/foundation.aar release-artifacts/ui-foundation-${{ steps.version.outputs.value }}.aar
           cp shape/build/outputs/aar/shape.aar release-artifacts/ui-shape-${{ steps.version.outputs.value }}.aar
           cp motion/build/outputs/aar/motion.aar release-artifacts/ui-motion-${{ steps.version.outputs.value }}.aar
           cp compose/build/outputs/aar/compose.aar release-artifacts/ui-${{ steps.version.outputs.value }}.aar
+          cp catalog/build/outputs/apk/release/catalog-release.apk release-artifacts/catalog-${{ steps.version.outputs.value }}.apk
           ls -la release-artifacts
 
-      - name: Attach AARs to GitHub Release
+      - name: Attach artifacts to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: release-artifacts/*.aar
+          files: release-artifacts/*
           generate_release_notes: true

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -23,6 +23,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            // Sign with debug key so CI can produce a distributable APK without
+            // a dedicated release keystore. The catalog is a showcase app, not a
+            // production release, so debug signing is acceptable.
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -11,7 +11,7 @@ CortenaUI publishes four artifacts to **Maven Central** under the `io.github.cor
 
 The `ui` artifact is the meta-artifact users normally depend on — it transitively pulls every other module. The `ui-*` siblings let consumers cherry-pick.
 
-Publishing is automated through the `Publish` GitHub Actions workflow. Pushing a tag of the form `v<version>` (for example `v0.3.0-alpha`) triggers a build, signs every artifact, uploads them to Maven Central, and attaches the per-module AARs to a GitHub Release.
+Publishing is automated through the `Publish` GitHub Actions workflow. Pushing a tag of the form `v<version>` (for example `v0.3.0-alpha`) triggers a build, signs every artifact, uploads them to Maven Central, and attaches the per-module AARs and the catalog showcase APK to a GitHub Release.
 
 ## One-time setup
 
@@ -91,7 +91,7 @@ The tag push is what fires the Publish workflow. Watch progress at `https://gith
 
 When the workflow finishes, head to [central.sonatype.com](https://central.sonatype.com) → **Deployments** and confirm a draft deployment is staged. Review the artifacts, then click **Publish** to release to Maven Central. Artifacts become consumable about ten to thirty minutes after the publish click.
 
-A GitHub Release is also created automatically, with the four AARs attached as assets and release notes generated from commit history.
+A GitHub Release is also created automatically, with the four AARs and the catalog showcase APK attached as assets and release notes generated from commit history.
 
 ## Local testing before tagging
 
@@ -156,7 +156,7 @@ After tagging:
 - [ ] Workflow run is green at `https://github.com/cortenaui/cortenaui/actions`.
 - [ ] Deployment is visible at [central.sonatype.com](https://central.sonatype.com) → Deployments.
 - [ ] Reviewed and clicked **Publish** on the staging deployment.
-- [ ] Verified the GitHub Release page has the four AAR assets attached.
+- [ ] Verified the GitHub Release page has the four AAR assets and the catalog APK attached.
 - [ ] Smoke-tested in a fresh consumer project after Maven Central indexes the artifacts.
 
 ## Troubleshooting


### PR DESCRIPTION
Configure the catalog module to use debug signing so CI can build release APKs without a dedicated keystore. Update the publish GitHub workflow to assemble the catalog release APK and include it in release artifacts. Update the publishing documentation to reflect the new catalog APK asset.