### PR TITLE
feat(ListView): auto set separator insets for list item leading

### DIFF
--- a/catalog/src/main/kotlin/app/cortena/ui/catalog/demo/ListView.kt
+++ b/catalog/src/main/kotlin/app/cortena/ui/catalog/demo/ListView.kt
@@ -57,13 +57,10 @@ fun ListViewDemo() {
                     "Label" to Color(0xFF757575),
                     "Fill" to Color(0xFFE0E0E0),
                 )
-            secondaryColors.forEach { (name, color) ->
+            secondaryColors.forEach { (name) ->
                 item {
                     ListItem(
                         title = { Text(name, role = TextRole.BodyMedium) },
-                        leading = {
-                            Box(modifier = Modifier.size(24.dp).clip(CircleShape).background(color))
-                        },
                     )
                 }
             }

--- a/compose/src/commonMain/kotlin/framework/cortena/ui/components/ListItem.kt
+++ b/compose/src/commonMain/kotlin/framework/cortena/ui/components/ListItem.kt
@@ -45,6 +45,10 @@ fun ListItem(
     onClick: (() -> Unit)? = null,
 ) {
     val colors = LocalColors.current
+
+    // Report leading presence to ListView's tracker (if inside a ListView)
+    LocalListItemLeadingTracker.current?.let { it.hasLeading = leading != null }
+
     Row(
         modifier =
             modifier

--- a/compose/src/commonMain/kotlin/framework/cortena/ui/components/ListView.kt
+++ b/compose/src/commonMain/kotlin/framework/cortena/ui/components/ListView.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -18,13 +21,31 @@ import framework.cortena.ui.theme.LocalColors
 import framework.cortena.ui.typography.TextWeight
 
 /**
+ * Tracker provided by [ListView] to each item via [LocalListItemLeadingTracker]. [ListItem] writes
+ * to [hasLeading] during composition so that [ListView] can adjust the separator inset
+ * automatically.
+ */
+internal class ListItemLeadingTracker {
+    var hasLeading: Boolean = false
+}
+
+/**
+ * CompositionLocal that carries the current [ListItemLeadingTracker]. When `null`, the composable
+ * is not inside a [ListView] and no tracking occurs.
+ */
+internal val LocalListItemLeadingTracker =
+    staticCompositionLocalOf<ListItemLeadingTracker?> { null }
+
+/**
  * CortenaUI - ListView
  *
  * A rounded, card-like container for a group of [ListItem]s, creating an inset grouped list style.
  * Automatically inserts [Separator] dividers between items.
  *
- * Items are registered via the [ListViewScope.item] builder inside the [content] lambda. Separators
- * are drawn between each pair of items.
+ * Items are registered via the [ListViewScope.item] builder inside the [content] lambda. Separator
+ * insets are determined automatically: when a [ListItem] inside an item has a `leading` slot, the
+ * separator below it indents to 56.dp to align with the text. When there is no leading content, the
+ * separator uses a symmetrical 16.dp horizontal inset.
  *
  * @param modifier Modifier applied to the outer container.
  * @param title Optional section header, styled as uppercase small text above the card.
@@ -56,10 +77,17 @@ fun ListView(
                     .clip(RoundedShape(24.dp))
                     .background(Color(colors.surfaceVariant)),
         ) {
-            scope.items.forEachIndexed { index, item ->
-                item()
+            scope.items.forEachIndexed { index, itemContent ->
+                val tracker = remember { ListItemLeadingTracker() }
+                tracker.hasLeading = false // reset before each composition
+
+                CompositionLocalProvider(LocalListItemLeadingTracker provides tracker) {
+                    itemContent()
+                }
+
                 if (index < scope.items.lastIndex) {
-                    Separator(modifier = Modifier.padding(start = 56.dp, end = 16.dp))
+                    val startInset = if (tracker.hasLeading) 56.dp else 16.dp
+                    Separator(modifier = Modifier.padding(start = startInset, end = 16.dp))
                 }
             }
         }
@@ -68,7 +96,7 @@ fun ListView(
 
 /** Receiver scope for [ListView] content. Use [item] to register each row. */
 interface ListViewScope {
-    /** Registers a single row inside the [ListView]. */
+    /** Registers a single row inside the [ListView] - typically a [ListItem]. */
     fun item(content: @Composable () -> Unit)
 }
 

--- a/docs/components/ListView.md
+++ b/docs/components/ListView.md
@@ -32,33 +32,14 @@ interface ListViewScope {
 | ---------- | --------------- | ---------- | ---------------------------------------------------- |
 | `modifier` | `Modifier`      | `Modifier` | Standard Compose modifier.                           |
 | `title`    | `String?`       | `null`     | Optional section header (rendered uppercase).        |
-| `content`  | `ListViewScope` | —          | Scope builder. Call `item { }` to register each row. |
+| `content`  | `ListViewScope` | -          | Scope builder. Call `item { }` to register each row. |
 
 ## Examples
 
-### Basic grouped list
+### With leading icons
 
 ```kotlin
 ListView(title = "Colors") {
-    item {
-        ListItem(
-            title = { Text("Red", role = TextRole.BodyMedium) },
-            leading = { Box(modifier = Modifier.size(24.dp).clip(CircleShape).background(Color.Red)) },
-        )
-    }
-    item {
-        ListItem(
-            title = { Text("Blue", role = TextRole.BodyMedium) },
-            leading = { Box(modifier = Modifier.size(24.dp).clip(CircleShape).background(Color.Blue)) },
-        )
-    }
-}
-```
-
-### Programmatic item generation
-
-```kotlin
-ListView(title = "FANCY") {
     colors.forEach { (name, color) ->
         item {
             ListItem(
@@ -68,6 +49,22 @@ ListView(title = "FANCY") {
                 },
             )
         }
+    }
+}
+```
+
+### Without leading
+
+```kotlin
+ListView(title = "Settings") {
+    item {
+        ListItem(title = { Text("Notifications", role = TextRole.BodyMedium) })
+    }
+    item {
+        ListItem(title = { Text("Privacy", role = TextRole.BodyMedium) })
+    }
+    item {
+        ListItem(title = { Text("About", role = TextRole.BodyMedium) })
     }
 }
 ```


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
* **Impact:** Medium - Enhances visual polish by automatically adjusting list separators, and establishes core project documentation for AI tools.
* **Key Changes:**
  * **Dynamic Separator Insets:** `ListView` now calculates the starting inset of its `Separator` dynamically. It indents to `56.dp` if the preceding `ListItem` has a leading icon, and `16.dp` if it does not.
  * **Component State Tracking:** Introduced `ListItemLeadingTracker` and a `CompositionLocal` to allow child `ListItem` components to report their structural state (presence of a leading slot) back to the parent `ListView`.
  * **Documentation & Demos:** Updated `ListView.md` and the catalog demo to showcase mixed lists with and without leading icons.
  * **AI Context File:** Added a comprehensive `CLAUDE.md` file that strictly defines the project's architecture, design philosophy, and zero-dependency rules for core modules.

## 2. Visual Overview (Code & Logic Map)

```mermaid
graph TD
    classDef primary fill:#bbdefb,color:#0d47a1,stroke:#0d47a1;
    classDef secondary fill:#c8e6c9,color:#1a5e20,stroke:#1a5e20;
    classDef state fill:#fff3e0,color:#e65100,stroke:#e65100;

    LV["ListView()"]:::primary -->|"Creates & Provides"| Tracker["LocalListItemLeadingTracker"]:::state
    LV -->|"Invokes"| Content["itemContent()"]:::primary
    
    subgraph "Child Composition"
        Content --> LI["ListItem()"]:::secondary
        LI -->|"Evaluates leading != null"| Update["it.hasLeading = true/false"]:::secondary
        Update -->|"Updates"| Tracker
    end
    
    Tracker -->|"Reads tracker.hasLeading"| SepLogic["Calculate startInset"]:::state
    SepLogic -->|"hasLeading == true"| Sep56["Separator(start = 56.dp)"]:::primary
    SepLogic -->|"hasLeading == false"| Sep16["Separator(start = 16.dp)"]:::primary
```

## 3. Detailed Change Analysis

### Component: `ListView` & `ListItem` (Compose Framework)
* **What Changed:** The list container now dynamically aligns its separators with the text of the list items above them. A tracking mechanism was introduced so that `ListItem` can communicate upwards during the composition phase, allowing `ListView` to draw the subsequent separator with the correct horizontal padding.
  * *Source:* `compose/src/commonMain/kotlin/framework/cortena/ui/components/ListView.kt`
  * *Source:* `compose/src/commonMain/kotlin/framework/cortena/ui/components/ListItem.kt`

| Internal API Added | Type | Description |
|---|---|---|
| `ListItemLeadingTracker` | `class` | A mutable state holder containing a single `hasLeading: Boolean` property. |
| `LocalListItemLeadingTracker` | `CompositionLocal` | Provides the tracker to child composables. It is nullable so `ListItem` can safely be used outside of a `ListView` without crashing. |

### Component: Catalog & Docs
* **What Changed:** The catalog demo for `ListView` was modified to remove leading icons from some items, effectively proving that the fallback `16.dp` inset works. The official Markdown documentation was similarly updated to show "With leading icons" and "Without leading" examples.

### Component: Project Infrastructure
* **What Changed:** Added `CLAUDE.md` to serve as a foundational rulebook for AI assistants. It documents the separation of the `:foundation`, `:shape`, `:motion`, and `:compose` modules, enforcing strict rules like "zero third-party dependencies" and "framework-agnostic geometry."

## 4. Impact & Risk Assessment
* **Breaking Changes:** None. The public API surface for `ListView` and `ListItem` remains unchanged.
* **Testing Suggestions:** 
  * Verify a `ListView` containing only `ListItem`s **with** `leading` components (separators should indent to `56.dp`).
  * Verify a `ListView` containing only `ListItem`s **without** `leading` components (separators should indent to `16.dp`).
  * Verify a mixed `ListView` with alternating items (separators should adjust individually per item based on the row immediately above them).
  * Ensure `ListItem` still renders correctly when placed outside of a `ListView` (fallback to `null` CompositionLocal).